### PR TITLE
Add "Weeklies" tags and events (#367)

### DIFF
--- a/lib/event_generators/weekly_report_events.rb
+++ b/lib/event_generators/weekly_report_events.rb
@@ -1,0 +1,61 @@
+require 'json'
+require 'date'
+
+class WeeklyReportEvents
+
+  def cve_from_filename(f)
+    f.match(/.*(?<cve>CVE-.*-.*)-weekly.json/)[:cve]
+  end
+
+  def generate(repo_path)
+    events = []
+    Dir["#{repo_path}/commits/weeklies/*.json"].each do |file|
+      json = File.open(file) { |f| JSON.load(f) }
+      v = Vulnerability.find_by(cve: cve_from_filename(file))
+      if v.nil?
+        puts "WARNING: weekly report for #{file}, but vuln not found"
+      else
+        json.each do |_week, report|
+          events << overall_report_event(v, report)
+        end
+      end
+    end
+    puts "Importing..."
+    Event.import events.compact
+  end
+
+  # Always create an event for a week with commits
+  def overall_report_event(v, report)
+    churn = report['insertions'].to_i + report['deletions'].to_i
+    num_devs = report['developers'].size
+    nice_date = DateTime.parse(report['date']).strftime('%A, %B %d, %Y')
+    Event.new(
+      detail_id: v.id,
+      detail_type: v.class,
+      style: style,
+      title_template: "#{report['commits']} commits by #{num_devs} developers, " +
+                      "#{churn} lines changed",
+      description_template: <<~EOS ,
+        During the 7-day period starting on #{nice_date}, the code that was
+        impacted by this vulnerability had #{report['commits']} commits by
+        #{num_devs}.
+
+        Those changes involved #{report['insertions']} line(s) inserted
+        and #{report['deletions']} line(s) deleted, impacting a total of
+        #{report['files'].size} source code file(s). The impacted files were:
+
+        #{report['files'].map { |f| " * `" + f + '`'  }.join("\n") }
+      EOS
+      date_template: report['date']
+    )
+  end
+
+  def style
+    @style ||= Style.find_or_create_by!(
+      name: 'vulnerability',
+      icon: 'bug_report',
+      color: '#F07866',
+    )
+  end
+
+end

--- a/lib/event_generators/weekly_report_events.rb
+++ b/lib/event_generators/weekly_report_events.rb
@@ -23,6 +23,7 @@ class WeeklyReportEvents
         json.each do |_week, report|
           events << overall_report_event(v, report)
           events << new_developers_event(v, report)
+          events << ownership_change(v, report)
           num_devs += report['new_developers'].size
         end
         tags << too_many_cooks(v, cooks_tag, num_devs) if num_devs > 5
@@ -46,7 +47,7 @@ class WeeklyReportEvents
     num_devs = report['developers'].size
     Event.new(
       detail: v,
-      style: style,
+      style: overall_report_style,
       title_template: "#{report['commits']} commits by #{num_devs} developers, " +
                       "#{churn} lines changed",
       description_template: <<~EOS ,
@@ -69,7 +70,7 @@ class WeeklyReportEvents
     num_new_devs = report['new_developers'].size
     Event.new(
       detail: v,
-      style: style,
+      style: new_dev_style,
       date_template: report['date'],
       title_template: "#{num_new_devs} new developers",
       description_template: <<~EOS
@@ -90,6 +91,25 @@ class WeeklyReportEvents
     )
   end
 
+  def ownership_change(v, report)
+    return nil unless report['ownership_change']
+    Event.new(
+      detail: v,
+      style: ownership_style,
+      date_template: report['date'],
+      title_template: "Code ownership changed",
+      description_template: <<~EOS
+        On the week of #{nice_date(report)}, changes were made to a Chromium
+        OWNERS file related to the vulnerable code.
+
+        In Chromium, an OWNER is someone who has the power to approve commits
+        in the code review system. They wield significant influence on the
+        project. Changes in code ownership can indicate team restructuring by
+        adopting new members or removing members.
+      EOS
+    )
+  end
+
   def too_many_cooks(v, cooks_tag, num_devs)
     VulnerabilityTag.new(
       tag: cooks_tag,
@@ -98,11 +118,27 @@ class WeeklyReportEvents
     )
   end
 
-  def style
-    @style ||= Style.find_or_create_by!(
-      name: 'vulnerability',
-      icon: 'bug_report',
-      color: '#F07866',
+  def ownership_style
+    @ownership_style ||= Style.find_or_create_by!(
+      name: 'ownership style',
+      icon: 'face',
+      color: '#BB5093',
+    )
+  end
+
+  def new_dev_style
+    @new_dev_style ||= Style.find_or_create_by!(
+      name: 'new_dev_style',
+      icon: 'person',
+      color: '#B7AADE',
+    )
+  end
+
+  def overall_report_style
+    @overall_report_style ||= Style.find_or_create_by!(
+      name: 'overall_report_style',
+      icon: 'assignment',
+      color: '#4E67A1',
     )
   end
 

--- a/lib/event_generators/weekly_report_events.rb
+++ b/lib/event_generators/weekly_report_events.rb
@@ -4,41 +4,55 @@ require 'date'
 class WeeklyReportEvents
 
   def cve_from_filename(f)
-    f.match(/.*(?<cve>CVE-.*-.*)-weekly.json/)[:cve]
+    f.match(/.*(?<cve>CVE-.+-.+)-weekly.json/)[:cve]
   end
 
   def generate(repo_path)
+    logger = Logger.new(STDOUT, progname: 'data:chromium:events:weeklies')
     events = []
+    tags =   []
+    cooks_tag = add_cooks_tag
+    logger.info "Parsing JSON weeklies"
     Dir["#{repo_path}/commits/weeklies/*.json"].each do |file|
       json = File.open(file) { |f| JSON.load(f) }
       v = Vulnerability.find_by(cve: cve_from_filename(file))
       if v.nil?
         puts "WARNING: weekly report for #{file}, but vuln not found"
       else
+        num_devs = 0
         json.each do |_week, report|
           events << overall_report_event(v, report)
+          events << new_developers_event(v, report)
+          num_devs += report['new_developers'].size
         end
+        tags << too_many_cooks(v, cooks_tag, num_devs) if num_devs > 5
+        v.notes['num_devs'] = num_devs
+        v.save
       end
     end
-    puts "Importing..."
-    Event.import events.compact
+    logger.info "Inserting event and tag data"
+    events.compact!
+    vuln_events = events.map do |e|
+      VulnerabilityEvent.new(event: e, vulnerability: e.detail)
+    end
+    Event.import events
+    VulnerabilityEvent.import vuln_events
+    VulnerabilityTag.import tags
   end
 
   # Always create an event for a week with commits
   def overall_report_event(v, report)
     churn = report['insertions'].to_i + report['deletions'].to_i
     num_devs = report['developers'].size
-    nice_date = DateTime.parse(report['date']).strftime('%A, %B %d, %Y')
     Event.new(
-      detail_id: v.id,
-      detail_type: v.class,
+      detail: v,
       style: style,
       title_template: "#{report['commits']} commits by #{num_devs} developers, " +
                       "#{churn} lines changed",
       description_template: <<~EOS ,
-        During the 7-day period starting on #{nice_date}, the code that was
+        During the 7-day period starting on #{nice_date(report)}, the code that was
         impacted by this vulnerability had #{report['commits']} commits by
-        #{num_devs}.
+        #{num_devs} different developers.
 
         Those changes involved #{report['insertions']} line(s) inserted
         and #{report['deletions']} line(s) deleted, impacting a total of
@@ -50,11 +64,67 @@ class WeeklyReportEvents
     )
   end
 
+  def new_developers_event(v, report)
+    return nil unless report['new_developers'].any?
+    num_new_devs = report['new_developers'].size
+    Event.new(
+      detail: v,
+      style: style,
+      date_template: report['date'],
+      title_template: "#{num_new_devs} new developers",
+      description_template: <<~EOS
+        On the week of #{nice_date(report)},
+        #{num_new_devs} developer(s) committed to this code, and they have
+        never committed to this code before.
+
+        Familiarity is difficult to gain with code. Even for the best
+        developers, contributing to a piece of source code for the first time
+        means that they must understand the design decisions from previous
+        developers, any issues the code has had historically, and the coding
+        style. Thus, the first commit any developer makes is risky.
+
+        Furthermore, research has shown a strong correlation between code that
+        had many developers and code with vulnerabilities. Learn more about
+        that effect in the tag "Lesson: Too Many Cooks".
+      EOS
+    )
+  end
+
+  def too_many_cooks(v, cooks_tag, num_devs)
+    VulnerabilityTag.new(
+      tag: cooks_tag,
+      vulnerability: v,
+      note: "#{num_devs} different developers have made commits to the files fixed for this vulnerability."
+    )
+  end
+
   def style
     @style ||= Style.find_or_create_by!(
       name: 'vulnerability',
       icon: 'bug_report',
       color: '#F07866',
+    )
+  end
+
+  def nice_date(report)
+    DateTime.parse(report['date']).strftime('%A, %B %d, %Y')
+  end
+
+  def add_cooks_tag
+    Tag.find_by(shortname: 'cooks') || Tag.create!(
+      name: 'Lesson: Too Many Cooks',
+      shortname: 'cooks',
+      color: '#009696',
+      description: <<~EOS
+        To be written.
+
+        Provide a few paragraphs and references about how having multiple
+        developers work on a piece of code increases its liklihood of having a
+        vulnerability.
+
+        Note that we used 5 as an arbitrary threshold, but it's really more of
+        a spectrum.
+      EOS
     )
   end
 

--- a/lib/tasks/chromium.rake
+++ b/lib/tasks/chromium.rake
@@ -25,7 +25,7 @@ namespace :data do
     gitName = 'chromium-vulnerabilities'
     findAddress = "./tmp/checkout/" + gitName
     gitAddress = 'https://github.com/andymeneely/chromium-vulnerabilities.git'
-    gitBranch = 'master'
+    gitBranch = 'weekly'
     customEvent = "bounty"
     projectName = 'Chromium'
 
@@ -86,7 +86,7 @@ namespace :data do
     task :load => :environment do
       [
         ProjectLoader,
-        # GitLoader,
+        GitLoader,
         CodeNoteLoader,
         ReleaseLoader,
         VulnerabilityLoader,
@@ -99,17 +99,18 @@ namespace :data do
     desc 'Generate event models'
     task :events => :environment do
       [
-        SimilarEvents,
-        VulnerabilityEvents,
-        FixEvents,
-        VccEvents,
-        ReleaseEvents,
-        # InterestingCommitEvents,
-        CommitEvents,
-        BountyEvents,
+        # SimilarEvents,
+        # VulnerabilityEvents,
+        # FixEvents,
+        # VccEvents,
+        # ReleaseEvents,
+        # # InterestingCommitEvents,
+        # CommitEvents,
+        # BountyEvents,
+        WeeklyReportEvents,
       ].each do |generator|
         logger.info "Generating #{generator.to_s.tableize.humanize.downcase}"
-        generator.new.generate
+        generator.new.generate(findAddress)
       end
     end
 

--- a/lib/tasks/chromium.rake
+++ b/lib/tasks/chromium.rake
@@ -25,7 +25,7 @@ namespace :data do
     gitName = 'chromium-vulnerabilities'
     findAddress = "./tmp/checkout/" + gitName
     gitAddress = 'https://github.com/andymeneely/chromium-vulnerabilities.git'
-    gitBranch = 'weekly'
+    gitBranch = 'master'
     customEvent = "bounty"
     projectName = 'Chromium'
 

--- a/lib/tasks/chromium.rake
+++ b/lib/tasks/chromium.rake
@@ -100,18 +100,19 @@ namespace :data do
     task :events => :environment do
       [
         # SimilarEvents,
-        # VulnerabilityEvents,
-        # FixEvents,
-        # VccEvents,
-        # ReleaseEvents,
-        # # InterestingCommitEvents,
-        # CommitEvents,
-        # BountyEvents,
-        WeeklyReportEvents,
+        VulnerabilityEvents,
+        FixEvents,
+        VccEvents,
+        ReleaseEvents,
+        # InterestingCommitEvents,
+        CommitEvents,
+        BountyEvents,
       ].each do |generator|
         logger.info "Generating #{generator.to_s.tableize.humanize.downcase}"
-        generator.new.generate(findAddress)
+        generator.new.generate
       end
+      logger.info "Generating weekly report events and tags"
+      WeeklyReportEvents.new.generate(findAddress)
     end
 
     desc 'Generate and apply tags'

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,7 @@
 datatables.net-dt@^1.10.15:
   version "1.10.19"
   resolved "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-1.10.19.tgz#fc668e4942ac6e331be2707975d0f33e01afb60f"
+  integrity sha512-joFHYjLYvr9VnC9Fx3e+8jtXnQ/fP/mPFWt9p0NhZ3Zm5N0jlYyWhJQbnLkihOLuDcDFMaGdBQSvmIdTVdgGyw==
   dependencies:
     datatables.net "1.10.19"
     jquery ">=1.7"
@@ -12,6 +13,7 @@ datatables.net-dt@^1.10.15:
 datatables.net-responsive-dt@^2.2.3:
   version "2.2.3"
   resolved "https://registry.npmjs.org/datatables.net-responsive-dt/-/datatables.net-responsive-dt-2.2.3.tgz#dbba47b61945ab35580a9266debc7fd3c56241f6"
+  integrity sha512-NGxuii+3sWGG150AWmQ5NYCrTaFKUHo6GeizBR8o2Uuy68PnuNrSO27hyLvOYNLHQ9kALT66f/gTaBc2TdznFA==
   dependencies:
     datatables.net-dt "^1.10.15"
     datatables.net-responsive "2.2.3"
@@ -20,6 +22,7 @@ datatables.net-responsive-dt@^2.2.3:
 datatables.net-responsive@2.2.3:
   version "2.2.3"
   resolved "https://registry.npmjs.org/datatables.net-responsive/-/datatables.net-responsive-2.2.3.tgz#50a2b1b4955b16b32f573a3f00f473b0bfbee913"
+  integrity sha512-8D6VtZcyuH3FG0Hn5A4LPZQEOX3+HrRFM7HjpmsQc/nQDBbdeBLkJX4Sh/o1nzFTSneuT1Wh/lYZHVPpjcN+Sw==
   dependencies:
     datatables.net "^1.10.15"
     jquery ">=1.7"
@@ -27,6 +30,7 @@ datatables.net-responsive@2.2.3:
 datatables.net-zf@^1.10.19:
   version "1.10.19"
   resolved "https://registry.yarnpkg.com/datatables.net-zf/-/datatables.net-zf-1.10.19.tgz#6e798e37b27eef57d2629de914eb5f7e8264bde0"
+  integrity sha512-mwYI8liKapeuVWrhhcrBC5KXxwHb8aDJ8ffRuM2jGntqjEqM2zseKi2ltA/9GfgbBVqTksmqKax3ZkVFZpTJcw==
   dependencies:
     datatables.net "1.10.19"
     jquery ">=1.7"
@@ -34,19 +38,23 @@ datatables.net-zf@^1.10.19:
 datatables.net@1.10.19, datatables.net@^1.10.15, datatables.net@^1.10.19:
   version "1.10.19"
   resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.10.19.tgz#97a1ed41c85e62d61040603481b59790a172dd1f"
+  integrity sha512-+ljXcI6Pj3PTGy5pesp3E5Dr3x3AV45EZe0o1r0gKENN2gafBKXodVnk2ypKwl2tTmivjxbkiqoWnipTefyBTA==
   dependencies:
     jquery ">=1.7"
 
 jquery-ujs@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/jquery-ujs/-/jquery-ujs-1.2.2.tgz#6a8ef1020e6b6dda385b90a4bddc128c21c56397"
+  integrity sha1-ao7xAg5rbdo4W5CkvdwSjCHFY5c=
   dependencies:
     jquery ">=1.8.0"
 
 jquery@>=1.7, jquery@>=1.8.0, jquery@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
 
 moment@^2.22.2:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+  integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=


### PR DESCRIPTION
For #367, we want to generate events that are based on 1-week units of time

* An overall weekly report, if there were any commits
* New developer events - see when new people joined
* Ownership events