### PR TITLE
Fix for #420 - reimplement event sorting function

### DIFF
--- a/app/assets/javascripts/vulnerabilities/show.js
+++ b/app/assets/javascripts/vulnerabilities/show.js
@@ -26,8 +26,8 @@ function initHTimeline(){
 //   * maxZoomDate - latest Fix
 //   * zoom comment - title text of what you're zooming into
 function findImportantDates(vuln_events){
-  minDate = vuln_events[0].date;
-  maxDate = vuln_events[vuln_events.length - 1].date;
+  minDate = vuln_events[vuln_events.length - 1].date;
+  maxDate = vuln_events[0].date;
   minZoomDate = minDate; // might be overwritten
   maxZoomDate = maxDate; // might be overwritten
   vuln_events.forEach(function(e) {
@@ -53,7 +53,9 @@ function findImportantDates(vuln_events){
  */
 function sortEvents(events) {
     events.sort(function(a, b) {
-        return a.date - b.date;
+        var a = new Date(a.date);
+        var b = new Date(b.date);
+        return b.getTime() - a.getTime();
     });
     return events;
 }


### PR DESCRIPTION
Events return unsorted from the API. The previous implementation of the sorting function simply obtained the string form of the timestamp for an event and subtracted it from another string timestamp. Because they were strings, the subtraction operation failed. Parsing the strings as Date objects and subtracting two Date objects using the getTime() function returned the expected, sorted results.