### PR TITLE
Add small and big fix taggers (#435)

### DIFF
--- a/lib/taggers/fix_tagger.rb
+++ b/lib/taggers/fix_tagger.rb
@@ -1,48 +1,48 @@
 class FixTagger
 
   def create_tags
-    @Big_Fix_Tag = Tag.create!(
+    @big_fix_tag = Tag.create!(
       name: 'Fix: Big',
-      shortname: 'Big Fix',
+      shortname: 'big fix',
       color: '#9FE69F',
-      description: "The fix for this vulnerability has more than 100 lines of changed code."
+      description: "This tag is applied when at least one fix for the vulnerability has more than 100 lines of changed code."
     )
-    @Small_Fix_Tag = Tag.create!(
+    @small_fix_tag = Tag.create!(
       name: 'Fix: Small',
-      shortname: 'Small Fix',
+      shortname: 'small fix',
       color: '#9FE69F',
-      description: "The fix for this vulnerability has less than 20 lines of changed code."
+      description: "This tag is applied when at least one fix for the vulnerability has fewer than 20 lines of changed code."
     )
   end
 
   def apply_tags
     tags = []
-    query = "SELECT vulnerabilities.id FROM commit_filepaths
+    query = "SELECT DISTINCT vulnerabilities.id FROM commit_filepaths
               INNER JOIN fixes ON commit_filepaths.commit_id = fixes.commit_id
               INNER JOIN vulnerabilities ON fixes.vulnerability_id = vulnerabilities.id
-              GROUP BY vulnerabilities.id
+              GROUP BY vulnerabilities.id,fixes.commit_id
               HAVING SUM(total_churn) > 100;"
     results = ActiveRecord::Base.connection.execute(query)
 
     results.each do |v|
       t = VulnerabilityTag.new(
         vulnerability_id: v['id'],
-        tag: @Big_Fix_Tag
+        tag: @big_fix_tag
       )
       tags << t
     end
 
-    query = "SELECT vulnerabilities.id FROM commit_filepaths
+    query = "SELECT DISTINCT vulnerabilities.id FROM commit_filepaths
               INNER JOIN fixes ON commit_filepaths.commit_id = fixes.commit_id
               INNER JOIN vulnerabilities ON fixes.vulnerability_id = vulnerabilities.id
-              GROUP BY vulnerabilities.id
+              GROUP BY vulnerabilities.id,fixes.commit_id
               HAVING SUM(total_churn) < 20;"
     results = ActiveRecord::Base.connection.execute(query)
 
     results.each do |v|
       t = VulnerabilityTag.new(
         vulnerability_id: v['id'],
-        tag: @Small_Fix_Tag
+        tag: @small_fix_tag
       )
       tags << t
     end

--- a/lib/taggers/fix_tagger.rb
+++ b/lib/taggers/fix_tagger.rb
@@ -1,0 +1,52 @@
+class FixTagger
+
+  def create_tags
+    @Big_Fix_Tag = Tag.create!(
+      name: 'Fix: Big',
+      shortname: 'Big Fix',
+      color: '#9FE69F',
+      description: "The fix for this vulnerability has more than 100 lines of changed code."
+    )
+    @Small_Fix_Tag = Tag.create!(
+      name: 'Fix: Small',
+      shortname: 'Small Fix',
+      color: '#9FE69F',
+      description: "The fix for this vulnerability has less than 20 lines of changed code."
+    )
+  end
+
+  def apply_tags
+    tags = []
+    query = "SELECT vulnerabilities.id FROM commit_filepaths
+              INNER JOIN fixes ON commit_filepaths.commit_id = fixes.commit_id
+              INNER JOIN vulnerabilities ON fixes.vulnerability_id = vulnerabilities.id
+              GROUP BY vulnerabilities.id
+              HAVING SUM(total_churn) > 100;"
+    results = ActiveRecord::Base.connection.execute(query)
+
+    results.each do |v|
+      t = VulnerabilityTag.new(
+        vulnerability_id: v['id'],
+        tag: @Big_Fix_Tag
+      )
+      tags << t
+    end
+
+    query = "SELECT vulnerabilities.id FROM commit_filepaths
+              INNER JOIN fixes ON commit_filepaths.commit_id = fixes.commit_id
+              INNER JOIN vulnerabilities ON fixes.vulnerability_id = vulnerabilities.id
+              GROUP BY vulnerabilities.id
+              HAVING SUM(total_churn) < 20;"
+    results = ActiveRecord::Base.connection.execute(query)
+
+    results.each do |v|
+      t = VulnerabilityTag.new(
+        vulnerability_id: v['id'],
+        tag: @Small_Fix_Tag
+      )
+      tags << t
+    end
+
+    VulnerabilityTag.import tags
+  end
+end

--- a/lib/tasks/chromium.rake
+++ b/lib/tasks/chromium.rake
@@ -128,6 +128,7 @@ namespace :data do
         ErrorOfOmissionTagger,
         LanguageTagger,
         LessonsTagger,
+        FixTagger,
         SubsystemTagger,
         UnitTestTagger
       ].each do |tagger|


### PR DESCRIPTION
Any vulnerability that has at least one fix that changed more than 100 lines of code will be tagged as "Fix: Big". Any vulnerability that has at least one fix that changed fewer than 20 lines of code will be tagged as "Fix: Small".