### PR TITLE
VHP-flavored markdown links to models (#427)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,23 +12,31 @@ module ApplicationHelper
     # Rinku will find any URLs not already in <a> tags and link em
     html = Rinku.auto_link(markdownified, mode=:all, link_attr=nil, skip_tags=nil)
 
-    # Autolinks all vulnerabilities following the format CVE-####-#### (case insensitive).
+    # Autolink all vulnerabilities following the format CVE-####-#### (case insensitive).
     # The rightmost number can be 4+ digits long according to
     # https://cve.mitre.org/about/faqs.html#cve_id_syntax_change
-    icon = "<i class='material-icons'>bug_report</i>"
     cves = html.scan(/(CVE-\d{4}-\d{4,})/i)
-    cves.each { |s| html.sub!(s[0].to_s,
-      "#{icon}<a href=\"/cves/#{s[0].to_s}\">#{s[0].to_s}</a>") }
+    cves.each {|s| html.sub!(s[0].to_s,
+      "<a href=\"/cves/#{s[0].to_s}\">#{s[0].to_s}</a>")}
 
+    # Identify all icon names placed between two colons, like :fi-camera:
+    # All icon names are replaced with an <i> tag and appropriate class.
+    # ":mi-bug-report:" turns into "<i class=\"vhp-icons-mi-bug-report\"></i>"
+    prefix = "vhp-icons-"
+    raw_icons = html.scan(/:[a-zA-Z-]*:/)
+    raw_icons.each {|i| html.sub!(i.to_s,
+      "<i class=\"#{prefix}#{i[1...-1].to_s}\"></i>")}
+
+    # Transformer used by Sanitize
     icon_transformer = lambda do |env|
       return unless env[:node_name] == 'i'
       node = env[:node]
-      class_attr = node['class']
+      class_name = node['class']
 
-      # If the class of the <i> tag is material-icons, then sanitize it down to
-      # only include a class attribute. Otherwise, don't allow anything through
-      # other than the <i> tag itself.
-      if class_attr == 'material-icons'
+      # Only allow a class attribute on an <i> tag if the class starts with
+      # the prefix used to designate an icon. All other attributes should
+      # be removed from the tag.
+      if not class_name.nil? and class_name.start_with?(prefix)
         Sanitize.node!(node, {
           :elements => ['i'],
           :attributes => {'i' => ['class']}
@@ -47,7 +55,6 @@ module ApplicationHelper
     # But we also want to allow icons, so we use a transformer to accomplish this.
     # See https://github.com/rgrove/sanitize for configs.
     scrubbed = Sanitize.fragment(html, Sanitize::Config.merge(Sanitize::Config::BASIC,
-      #:attributes      => Sanitize::Config::BASIC[:attributes].merge('i' => ['class']),
       :transformers    => icon_transformer,
       :remove_contents => true
     ))

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,13 +15,42 @@ module ApplicationHelper
     # Autolinks all vulnerabilities following the format CVE-####-#### (case insensitive).
     # The rightmost number can be 4+ digits long according to
     # https://cve.mitre.org/about/faqs.html#cve_id_syntax_change
+    icon = "<i class='material-icons'>bug_report</i>"
     cves = html.scan(/(CVE-\d{4}-\d{4,})/i)
-    cves.each { |s| html.sub!(s[0].to_s, "<a href=\"/cves/#{s[0].to_s}\">#{s[0].to_s}</a>") }
+    cves.each { |s| html.sub!(s[0].to_s,
+      "#{icon}<a href=\"/cves/#{s[0].to_s}\">#{s[0].to_s}</a>") }
+
+    icon_transformer = lambda do |env|
+      return unless env[:node_name] == 'i'
+      node = env[:node]
+      class_attr = node['class']
+
+      # If the class of the <i> tag is material-icons, then sanitize it down to
+      # only include a class attribute. Otherwise, don't allow anything through
+      # other than the <i> tag itself.
+      if class_attr == 'material-icons'
+        Sanitize.node!(node, {
+          :elements => ['i'],
+          :attributes => {'i' => ['class']}
+        })
+      else
+        Sanitize.node!(node, {
+          :elements => ['i']
+        })
+      end
+
+      {:node_whitelist => [node]}
+    end
 
     # We sanitize AFTER everything is transformed, and Sanitize is smart enough to
     # allow only certain kinds of links. We need to allow links, hence BASIC.
+    # But we also want to allow icons, so we use a transformer to accomplish this.
     # See https://github.com/rgrove/sanitize for configs.
-    scrubbed = Sanitize.fragment(html, Sanitize::Config::BASIC)
+    scrubbed = Sanitize.fragment(html, Sanitize::Config.merge(Sanitize::Config::BASIC,
+      #:attributes      => Sanitize::Config::BASIC[:attributes].merge('i' => ['class']),
+      :transformers    => icon_transformer,
+      :remove_contents => true
+    ))
     raw(scrubbed).html_safe
   end
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -55,9 +55,21 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal expected, markdown(input)
   end
 
-  test 'icons are still blocked' do
+  test 'icons are allowed in <i>' do
     input =    "<i class=\"material-icons\">bug_report</i>"
-    expected = "<p><i>bug_report</i></p>\n"
+    expected = "<p><i class=\"material-icons\">bug_report</i></p>\n"
+    assert_equal expected, markdown(input)
+  end
+
+  test 'classes not whitelisted in <i> are blocked' do
+    input =    "<i class=\"nefarious\"></i>"
+    expected = "<p><i></i></p>\n"
+    assert_equal expected, markdown(input)
+  end
+
+  test 'multiple classes in <i> are blocked' do
+    input =    "<i class=\"nefarious material-icons\"></i>"
+    expected = "<p><i></i></p>\n"
     assert_equal expected, markdown(input)
   end
 
@@ -69,19 +81,19 @@ class ApplicationHelperTest < ActionView::TestCase
 
   test 'auto linking to normal cve' do
     input =    "CVE-2013-6657"
-    expected = "<p><a href=\"/cves/CVE-2013-6657\" rel=\"nofollow\">CVE-2013-6657</a></p>\n"
+    expected = "<p><i class=\"material-icons\">bug_report</i><a href=\"/cves/CVE-2013-6657\" rel=\"nofollow\">CVE-2013-6657</a></p>\n"
     assert_equal expected, markdown(input)
   end
 
   test 'auto linking to long cve' do
     input =    "CVE-2014-105823059"
-    expected = "<p><a href=\"/cves/CVE-2014-105823059\" rel=\"nofollow\">CVE-2014-105823059</a></p>\n"
+    expected = "<p><i class=\"material-icons\">bug_report</i><a href=\"/cves/CVE-2014-105823059\" rel=\"nofollow\">CVE-2014-105823059</a></p>\n"
     assert_equal expected, markdown(input)
   end
 
   test 'auto linking to lowercase cve' do
     input =    "cve-2014-9482"
-    expected = "<p><a href=\"/cves/cve-2014-9482\" rel=\"nofollow\">cve-2014-9482</a></p>\n"
+    expected = "<p><i class=\"material-icons\">bug_report</i><a href=\"/cves/cve-2014-9482\" rel=\"nofollow\">cve-2014-9482</a></p>\n"
     assert_equal expected, markdown(input)
   end
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -55,25 +55,37 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal expected, markdown(input)
   end
 
-  test 'icons are allowed in <i>' do
-    input =    "<i class=\"material-icons\">bug_report</i>"
-    expected = "<p><i class=\"material-icons\">bug_report</i></p>\n"
+  test 'auto linking for single icon' do
+    input =    ":mi-bug-report:"
+    expected = "<p><i class=\"vhp-icons-mi-bug-report\"></i></p>\n"
     assert_equal expected, markdown(input)
   end
 
-  test 'classes not whitelisted in <i> are blocked' do
+  test 'auto linking for multiple icons' do
+    input =    "Here are two icons: :mi-bug-report: :fi-camera:"
+    expected = "<p>Here are two icons: <i class=\"vhp-icons-mi-bug-report\"></i> <i class=\"vhp-icons-fi-camera\"></i></p>\n"
+    assert_equal expected, markdown(input)
+  end
+
+  test 'pre-existing icon tags are allowed' do
+    input =    "<i class=\"vhp-icons-mi-bug-report\"></i>"
+    expected = "<p><i class=\"vhp-icons-mi-bug-report\"></i></p>\n"
+    assert_equal expected, markdown(input)
+  end
+
+  test 'non-icon class names in <i> are blocked' do
     input =    "<i class=\"nefarious\"></i>"
     expected = "<p><i></i></p>\n"
     assert_equal expected, markdown(input)
   end
 
   test 'multiple classes in <i> are blocked' do
-    input =    "<i class=\"nefarious material-icons\"></i>"
+    input =    "<i class=\"nefarious vhp-icons-mi-bug-report\"></i>"
     expected = "<p><i></i></p>\n"
     assert_equal expected, markdown(input)
   end
 
-  test 'auto linking still not done on invalid cve' do
+  test 'auto linking not done on invalid cve' do
     input =    "CVE-2013-665"
     expected = "<p>CVE-2013-665</p>\n"
     assert_equal expected, markdown(input)
@@ -81,19 +93,19 @@ class ApplicationHelperTest < ActionView::TestCase
 
   test 'auto linking to normal cve' do
     input =    "CVE-2013-6657"
-    expected = "<p><i class=\"material-icons\">bug_report</i><a href=\"/cves/CVE-2013-6657\" rel=\"nofollow\">CVE-2013-6657</a></p>\n"
+    expected = "<p><a href=\"/cves/CVE-2013-6657\" rel=\"nofollow\">CVE-2013-6657</a></p>\n"
     assert_equal expected, markdown(input)
   end
 
   test 'auto linking to long cve' do
     input =    "CVE-2014-105823059"
-    expected = "<p><i class=\"material-icons\">bug_report</i><a href=\"/cves/CVE-2014-105823059\" rel=\"nofollow\">CVE-2014-105823059</a></p>\n"
+    expected = "<p><a href=\"/cves/CVE-2014-105823059\" rel=\"nofollow\">CVE-2014-105823059</a></p>\n"
     assert_equal expected, markdown(input)
   end
 
   test 'auto linking to lowercase cve' do
     input =    "cve-2014-9482"
-    expected = "<p><i class=\"material-icons\">bug_report</i><a href=\"/cves/cve-2014-9482\" rel=\"nofollow\">cve-2014-9482</a></p>\n"
+    expected = "<p><a href=\"/cves/cve-2014-9482\" rel=\"nofollow\">cve-2014-9482</a></p>\n"
     assert_equal expected, markdown(input)
   end
 


### PR DESCRIPTION
I've added support for icons. Right now, only CVEs are auto-linked and are displayed with a bug icon to the left of the link. Minor aesthetic changes will need to be made to how icons are displayed.

Depending on how we decide to implement the linking of the other models (tags, filepaths, etc.), we might be able to just add more regex expressions and other logic in the application helper. If we decide to not do any special keyword extraction from the text and just use Markdown and Kramdown as discussed on #427, then we may not be using any of this.