### PR TITLE
Update vhp-icon prefix and tests

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,7 @@ module ApplicationHelper
     # Identify all icon names placed between two colons, like :fi-camera:
     # All icon names are replaced with an <i> tag and appropriate class.
     # ":mi-bug-report:" turns into "<i class=\"vhp-icons-mi-bug-report\"></i>"
-    prefix = "vhp-icons-"
+    prefix = "vhp-icon-"
     raw_icons = html.scan(/:[a-zA-Z-]*:/)
     raw_icons.each {|i| html.sub!(i.to_s,
       "<i class=\"#{prefix}#{i[1...-1].to_s}\"></i>")}

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -56,20 +56,20 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   test 'auto linking for single icon' do
-    input =    ":mi-bug-report:"
-    expected = "<p><i class=\"vhp-icons-mi-bug-report\"></i></p>\n"
+    input =    "Here is a vulnerability icon: :vulnerability:"
+    expected = "<p>Here is a vulnerability icon: <i class=\"vhp-icon-vulnerability\"></i></p>\n"
     assert_equal expected, markdown(input)
   end
 
   test 'auto linking for multiple icons' do
-    input =    "Here are two icons: :mi-bug-report: :fi-camera:"
-    expected = "<p>Here are two icons: <i class=\"vhp-icons-mi-bug-report\"></i> <i class=\"vhp-icons-fi-camera\"></i></p>\n"
+    input =    "Here are two icons: :vulnerability: :info:"
+    expected = "<p>Here are two icons: <i class=\"vhp-icon-vulnerability\"></i> <i class=\"vhp-icon-info\"></i></p>\n"
     assert_equal expected, markdown(input)
   end
 
   test 'pre-existing icon tags are allowed' do
-    input =    "<i class=\"vhp-icons-mi-bug-report\"></i>"
-    expected = "<p><i class=\"vhp-icons-mi-bug-report\"></i></p>\n"
+    input =    "<i class=\"vhp-icon-graph-pie\"></i>"
+    expected = "<p><i class=\"vhp-icon-graph-pie\"></i></p>\n"
     assert_equal expected, markdown(input)
   end
 
@@ -80,7 +80,7 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   test 'multiple classes in <i> are blocked' do
-    input =    "<i class=\"nefarious vhp-icons-mi-bug-report\"></i>"
+    input =    "<i class=\"nefarious vhp-icon-vulnerability\"></i>"
     expected = "<p><i></i></p>\n"
     assert_equal expected, markdown(input)
   end


### PR DESCRIPTION
Icon names between colons will be automatically detected and replaced with the appropriate \<i\> tag and class name. Previously, the wrong prefix was being used for class names. The prefix has been "depluralized" to match the prefix used in the SCSS file. 