### PR TITLE
Hide email address on developer#show behind AJAX call

### DIFF
--- a/app/assets/javascripts/developers/show.js
+++ b/app/assets/javascripts/developers/show.js
@@ -57,7 +57,8 @@ $( document ).ready( function() {
 
     $('#email_fetch').on('click', function() {
         if (!input_detected) {
-          alert("We haven't detected any keyboard or mouse input from you. To display the email address, please show us you're not a bot.");
+          alert("We haven't detected any keyboard or mouse input from you. "
+                + "To display the email address, please first show us you're not a bot.");
           return;
         }
 

--- a/app/assets/javascripts/developers/show.js
+++ b/app/assets/javascripts/developers/show.js
@@ -33,26 +33,46 @@ $( document ).ready( function() {
            'cursor': 'pointer',
             'color': 'blue'
         });
-    })
+    });
 
     $('#datatable').on('mouseout', 'tbody tr', function() {
         $(this).css({
             'cursor': 'default',
             'color': 'inherit'
         });
-    })
+    });
+
+    // If mouse movement is detected, then the user is hopefully not a bot
+    var input_detected = false;
+    $(document).mousemove(function(event) {
+        input_detected = true;
+        $(document).off("mousemove");
+    });
+
+    // If keyboard input is detected, then the user is hopefully not a bot
+    $(document).keypress(function(event) {
+        input_detected = true;
+        $(document).off("keypress");
+    });
 
     $('#email_fetch').on('click', function() {
+        if (!input_detected) {
+          alert("We haven't detected any keyboard or mouse input from you. To display the email address, please show us you're not a bot.");
+          return;
+        }
+
         $.ajax({
             url: "/api/developers/" + $('#developer_id').text(),
             dataType: 'json',
             success: function(jsonData) {
               $('#email_fetch').hide();
-              $('#developer_email').html(jsonData.email);
-              $('#developer_email').show();
-              $('#github_search').prop('href', "https://github.com/search?q=" + jsonData.email + "&type=Users");
-              $('#github_search').html("<i class=\"vhp-icon-github\"></i> Search " + jsonData.email + " on GitHub");
-              $('#github_search').show();
+              $('#developer_email')
+                .html(jsonData.email)
+                .show();
+              $('#github_search')
+                .prop('href', "https://github.com/search?q=" + jsonData.email + "&type=Users")
+                .html("<i class=\"vhp-icon-github\"></i> Search for " + jsonData.email + " on GitHub")
+                .show();
             },
             error: function() {
               if ($('#email_fetch').html() == "Failed. Retry?") {
@@ -62,5 +82,5 @@ $( document ).ready( function() {
               }
             }
         });
-    })
+    });
 });

--- a/app/assets/javascripts/developers/show.js
+++ b/app/assets/javascripts/developers/show.js
@@ -41,4 +41,26 @@ $( document ).ready( function() {
             'color': 'inherit'
         });
     })
+
+    $('#email_fetch').on('click', function() {
+        $.ajax({
+            url: "/api/developers/" + $('#developer_id').text(),
+            dataType: 'json',
+            success: function(jsonData) {
+              $('#email_fetch').hide();
+              $('#developer_email').html(jsonData.email);
+              $('#developer_email').show();
+              $('#github_search').prop('href', "https://github.com/search?q=" + jsonData.email + "&type=Users");
+              $('#github_search').html("<i class=\"vhp-icon-github\"></i> Search " + jsonData.email + " on GitHub");
+              $('#github_search').show();
+            },
+            error: function() {
+              if ($('#email_fetch').html() == "Failed. Retry?") {
+                $('#email_fetch').html("Retry again?");
+              } else {
+                $('#email_fetch').html("Failed. Retry?");
+              }
+            }
+        });
+    })
 });

--- a/app/assets/stylesheets/developers.scss
+++ b/app/assets/stylesheets/developers.scss
@@ -2,11 +2,33 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-#datatable_wrapper {
-  margin: 5%;
-  margin-top: 1%;
-}
+@import "_settings.scss";
 
 .row {
   margin-top: 2%;
+}
+
+#github_search {
+  text-decoration: none;
+}
+
+#email_fetch {
+  color: $body-font-color;
+  box-sizing: border-box;
+  display: inline-block;
+  padding: 0.5em 1em;
+  margin-left: 0.1em;
+  text-align: center;
+  cursor: pointer;
+  border: 1px solid $medium-gray;
+  border-radius: 0.5em;
+}
+
+#email_fetch:hover {
+  border: 1px solid black;
+}
+
+#developer_email {
+  display: inline-block;
+  padding-top: 0.5em;
 }

--- a/app/assets/stylesheets/developers.scss
+++ b/app/assets/stylesheets/developers.scss
@@ -2,10 +2,10 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-@import "_settings.scss";
+@import "_settings";
 
 .row {
-  margin-top: 2%;
+  margin-top: 1.5em;
 }
 
 #github_search {
@@ -16,7 +16,7 @@
   color: $body-font-color;
   box-sizing: border-box;
   display: inline-block;
-  padding: 0.5em 1em;
+  padding: 0.3em 0.8em;
   margin-left: 0.1em;
   text-align: center;
   cursor: pointer;
@@ -30,5 +30,5 @@
 
 #developer_email {
   display: inline-block;
-  padding-top: 0.4em;
+  padding-top: 0.2em;
 }

--- a/app/assets/stylesheets/developers.scss
+++ b/app/assets/stylesheets/developers.scss
@@ -4,4 +4,9 @@
 
 #datatable_wrapper {
   margin: 5%;
+  margin-top: 1%;
+}
+
+.row {
+  margin-top: 2%;
 }

--- a/app/assets/stylesheets/developers.scss
+++ b/app/assets/stylesheets/developers.scss
@@ -30,5 +30,5 @@
 
 #developer_email {
   display: inline-block;
-  padding-top: 0.5em;
+  padding-top: 0.4em;
 }

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -14,11 +14,6 @@ class DevelopersController < ApplicationController
     render_json_for_api @developer
     @commits = @developer.commits
     logger.info(@commits)
-    @events = Event.joins("INNER JOIN commits
-                            ON (commits.id = events.detail_id
-                              AND events.detail_type = 'Commit')")
-                    .where( commits: { author_id: params[:id]} )
-    logger.info(@events)
   end
 
   def commits

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -2,34 +2,29 @@
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet">
 
+<div id="developer_id" style="display:none;"><%=@developer.id %></div>
+<% if @developer.email.include? '@' %>
+<h3>Developer's Email Address:
+  <button class="button" type="button" id="email_fetch">Fetch Email</button>
+  <span id="developer_email" class="hidden"></span>
+</h3>
+<% elsif @developer.email.include? ' ' %>
+<h3>Developer's Name: <%=@developer.email %></h3>
+<% else %>
+<h3>Developer's Username: <%=@developer.email %></h3>
+<% end %>
+<a class="button" id="github_search" href=""></a>
+
 <div class="row">
-
-  <div class="row">
-    <div id="developer_id" style="display:none;"><%=@developer.id %></div>
-    <% if @developer.email.include? '@' %>
-      <h3>Developer's Email Address:
-        <button class="button" type="button" id="email_fetch">Fetch Email</button>
-        <span id="developer_email" class="hidden"></span>
-      </h3>
-    <% elsif @developer.email.include? ' ' %>
-      <h3>Developer's Name: <%=@developer.email %></h3>
-    <% else %>
-      <h3>Developer's Username: <%=@developer.email %></h3>
-    <% end %>
-    <a class="button" id="github_search" href=""></a>
-  </div>
-
-  <div class="row">
-    <h3>Associated Commits:</h3>
-    <table id="datatable" class="display hover" width="100%">
-      <thead></thead>
-      <tbody></tbody>
-      <tfoot></tfoot>
-    </table>
-  </div>
-
-  <a href="#" class="scroll-to-top material-icons md-48 md-dark md-inactive">vertical_align_top</a>
-  <%= javascript_include_tag "developers/show" %>
-  <%= javascript_include_tag "timeline/timelines" %>
-  <%= javascript_include_tag "timeline" %>
+  <h3>Associated Commits:</h3>
+  <table id="datatable" class="display hover" width="100%">
+    <thead></thead>
+    <tbody></tbody>
+    <tfoot></tfoot>
+  </table>
 </div>
+
+<a href="#" class="scroll-to-top material-icons md-48 md-dark md-inactive">vertical_align_top</a>
+<%= javascript_include_tag "developers/show" %>
+<%= javascript_include_tag "timeline/timelines" %>
+<%= javascript_include_tag "timeline" %>

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -18,69 +18,9 @@
     </a>
   </div>
 
-  <header>
-    <div class="row">
-      <section id="horizontal-timeline"></section>
-    </div>
-  </header>
-
   <div class="row">
-    <div class="small-10 small-offset-1 columns">
-      <div class="data-toggles horizontal-center" id="toggle-block"></div>
-    </div>
-    <div class="small-1 columns horizontal-center" id="zoom-div">
-    <span id="zoom-button" class="button material-icons">
-      zoom_out
-    </span>
-      <input type="hidden" id="zoom-bool" name="zoom-bool" value=true>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="small-12 columns horizontal-center">
-      <div id="legend" class="callout secondary">
-        <h5 id="legend-body"></h5>
-      </div>
-    </div>
-  </div>
-
-  <section id="cd-timeline" class="cd-container">
-    <% @events.each do |e| %>
-        <div id="<%= e.type %>" data-id='<%= e.date %>'
-             class="cd-timeline-block">
-          <a id="<%= e.id %>"></a>
-          <div class="cd-timeline-img"
-               style="background: <%= e.style.color %>">
-            <p id="timeline-icon"
-               class="material-icons md-32 md-light">
-              <%= e.style.icon %>
-            </p>
-          </div> <!-- cd-timeline-img -->
-          <div class="cd-timeline-content">
-            <h2 id="title"><%= e.title %></h2>
-            <p id="description"><%= markdown(e.description) %></p>
-            <a class="see-more-link" href="/<%= e.type.pluralize %>/<%= e.detail_id %> ">See More...</a>
-            <span class="cd-date" id="date">
-            <% if e.date != nil %>
-              <div id="isodate" style="display:none"><%= e.date %></div>
-                  <%= pretty_date(e.date) %>
-            <% else %> <!-- if the time is not specified, use Time.current (this is a temporary fix) -->
-                  <%= Time.current %>
-            <% end %>
-          </span>
-          </div>
-
-        </div>
-    <% end %>
-  </section>
-
-  <section id="tooltips">
-  </section>
-
-  <div class="row">
-    <h3>Associated Commits: </h3>
-
-    <table id="datatable" class="display" width="100%">
+    <h3>Associated Commits:</h3>
+    <table id="datatable" class="display hover" width="100%">
       <thead></thead>
       <tbody></tbody>
       <tfoot></tfoot>

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -8,7 +8,7 @@
     <div id="developer_id" style="display:none;"><%=@developer.id %></div>
     <% if @developer.email.include? '@' %>
       <h3>Developer's Email Address:
-        <button type="button" id="email_fetch">Fetch Email</button>
+        <button class="button" type="button" id="email_fetch">Fetch Email</button>
         <span id="developer_email" class="hidden"></span>
       </h3>
     <% elsif @developer.email.include? ' ' %>
@@ -16,7 +16,7 @@
     <% else %>
       <h3>Developer's Username: <%=@developer.email %></h3>
     <% end %>
-    <a class="hidden button" id="github_search" href=""></a>
+    <a class="button" id="github_search" href=""></a>
   </div>
 
   <div class="row">

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -4,18 +4,19 @@
 
 <div class="row">
 
-  <div class="large-12 columns">
+  <div class="row">
     <div id="developer_id" style="display:none;"><%=@developer.id %></div>
     <% if @developer.email.include? '@' %>
-      <h3>Developer's Email Address: <%=@developer.email %></h3>
+      <h3>Developer's Email Address:
+        <button type="button" id="email_fetch">Fetch Email</button>
+        <span id="developer_email" class="hidden"></span>
+      </h3>
     <% elsif @developer.email.include? ' ' %>
       <h3>Developer's Name: <%=@developer.email %></h3>
     <% else %>
       <h3>Developer's Username: <%=@developer.email %></h3>
     <% end %>
-    <a class="button" href="https://github.com/search?q=<%=@developer.email%>&type=Users" style="text-decoration: none">
-      <i class="vhp-icon-github"></i> Search on GitHub
-    </a>
+    <a class="hidden button" id="github_search" href=""></a>
   </div>
 
   <div class="row">


### PR DESCRIPTION
Since the developer page was previously unable to load, I had to take out some code relating to the event-detail associations before I could start working on issue #506.

With this pull request, a developer's email address will not be displayed on the page until either mouse movement or keyboard input is detected from the user, and the user clicks on the "Fetch Email" button. When the user clicks that button, an AJAX call is made to `/api/developers/<id>` which returns their email address, and then that address is injected into the page.