### PR TITLE
Prevent double-tagging and eventing #504

### DIFF
--- a/lib/event_generators/bounty_events.rb
+++ b/lib/event_generators/bounty_events.rb
@@ -1,11 +1,15 @@
 class BountyEvents
 
+  def initialize(project)
+    @project = project
+  end
+
   def initialize
     @desc = File.read(File.expand_path("markdown/bounty.md", __dir__,))
   end
 
   def generate
-    Vulnerability.all.each do |vuln|
+    Vulnerability.where(project: @project).each do |vuln|
       if has_bounty? vuln
         if valid_date? vuln, vuln.notes['bounty']['date']
           e = Event.create!(

--- a/lib/event_generators/bounty_events.rb
+++ b/lib/event_generators/bounty_events.rb
@@ -2,9 +2,6 @@ class BountyEvents
 
   def initialize(project)
     @project = project
-  end
-
-  def initialize
     @desc = File.read(File.expand_path("markdown/bounty.md", __dir__,))
   end
 

--- a/lib/event_generators/fix_events.rb
+++ b/lib/event_generators/fix_events.rb
@@ -1,6 +1,7 @@
 class FixEvents
 
-  def initialize
+  def initialize(project)
+    @project = project
     tmpl = File.expand_path("markdown/commit.md", __dir__,)
     @desc = File.read(tmpl)
   end

--- a/lib/event_generators/fix_events.rb
+++ b/lib/event_generators/fix_events.rb
@@ -9,7 +9,9 @@ class FixEvents
   def generate
     events = []
     vuln_events = []
-    Fix.all.each do |fix|
+    Fix.joins(:vulnerability)
+       .where('vulnerabilities.project_id' => @project.id)
+       .each do |fix|
       e = Event.new(
         style: style,
         title: "Fix for #{fix.vulnerability.cve}: #{fix.commit.title}",
@@ -35,9 +37,5 @@ class FixEvents
   end
 
   private
-
-  def generate_description(f)
-    @desc.gsub(':bountyamount:', vulns.notes['bounty']['amount'])
-  end
 
 end

--- a/lib/event_generators/release_events.rb
+++ b/lib/event_generators/release_events.rb
@@ -1,4 +1,9 @@
 class ReleaseEvents
+
+  def initialize(project)
+    @project = project
+  end
+
   def generate
     events = create_release_events
     associate_with_vulnerabilities events

--- a/lib/event_generators/similar_events.rb
+++ b/lib/event_generators/similar_events.rb
@@ -24,6 +24,7 @@ class SimilarEvents
       INNER JOIN vulnerabilities AS v2 ON (vt2.vulnerability_id = v2.id)
       INNER JOIN tags AS t1 ON (t1.id = vt1.tag_id)
       WHERE t1.name LIKE 'CWE%'
+      AND v2.project_id = '#{@project.id}'
     EOSQL
     results = ActiveRecord::Base.connection.execute(query)
     results.each do |vuln|
@@ -32,7 +33,7 @@ class SimilarEvents
         event_type: 'Same CWE',
         title: "A similar vulnerability to this one was announced at this time. It has the same CWE type.",
         date:  vuln['announced'],
-        description: "Similar vulnerability: #{vuln['cve']} has the same CWE 119"
+        description: "Similar vulnerability: #{vuln['cve']} has the same CWE"
       )
       events << e
       vuln_events << VulnerabilityEvent.new(vulnerability_id: vuln['vuln1_id'], event: e)
@@ -63,9 +64,9 @@ class SimilarEvents
       INNER JOIN filepaths AS fp2 ON cf2.filepath_id = fp2.id
       WHERE fp1.dir = fp2.dir
             AND fp1.project_id = fp2.project_id
-            AND fp1.project_id = ?
+            AND fp1.project_id = '#{@project.id}'
     EOSQL
-    results = ActiveRecord::Base.connection.execute(query, @project.id)
+    results = ActiveRecord::Base.connection.execute(query)
     results.each do |vuln|
       dir = vuln['fp'].split('/')[0...-1].join('/')
       e = Event.new(

--- a/lib/event_generators/similar_events.rb
+++ b/lib/event_generators/similar_events.rb
@@ -1,5 +1,9 @@
 class SimilarEvents
 
+  def initialize(project)
+    @project = project
+  end
+
   def generate
     Rails.logger.info "Similar CWE events"
     cwe_events()
@@ -15,7 +19,7 @@ class SimilarEvents
     events = []
     vuln_events = []
     query = <<~EOSQL
-    SELECT vt1.vulnerability_id AS vuln1_id, vt2.vulnerability_id AS vuln2_id, v2.announced AS announced, v2.cve AS cve, t1.name AS cwe FROM vulnerability_tags AS vt1 
+    SELECT vt1.vulnerability_id AS vuln1_id, vt2.vulnerability_id AS vuln2_id, v2.announced AS announced, v2.cve AS cve, t1.name AS cwe FROM vulnerability_tags AS vt1
       INNER JOIN vulnerability_tags AS vt2 ON (vt1.tag_id = vt2.tag_id AND vt1.id <> vt2.id)
       INNER JOIN vulnerabilities AS v2 ON (vt2.vulnerability_id = v2.id)
       INNER JOIN tags AS t1 ON (t1.id = vt1.tag_id)
@@ -57,9 +61,11 @@ class SimilarEvents
       INNER JOIN commit_filepaths AS cf2 ON cf2.commit_id = c2.id
       INNER JOIN filepaths AS fp1 ON cf1.filepath_id = fp1.id
       INNER JOIN filepaths AS fp2 ON cf2.filepath_id = fp2.id
-      WHERE fp1.dir = fp2.dir AND fp1.project_id = fp2.project_id
+      WHERE fp1.dir = fp2.dir
+            AND fp1.project_id = fp2.project_id
+            AND fp1.project_id = ?
     EOSQL
-    results = ActiveRecord::Base.connection.execute(query)
+    results = ActiveRecord::Base.connection.execute(query, @project.id)
     results.each do |vuln|
       dir = vuln['fp'].split('/')[0...-1].join('/')
       e = Event.new(

--- a/lib/event_generators/vcc_events.rb
+++ b/lib/event_generators/vcc_events.rb
@@ -1,8 +1,9 @@
 class VccEvents
 
-  def initialize
-    tmpl = File.expand_path("markdown/vcc.md", __dir__)
+  def initialize(project)
+    @project = project
     @desc = File.read(tmpl)
+    tmpl = File.expand_path("markdown/vcc.md", __dir__)
   end
 
   def generate

--- a/lib/event_generators/vcc_events.rb
+++ b/lib/event_generators/vcc_events.rb
@@ -2,14 +2,16 @@ class VccEvents
 
   def initialize(project)
     @project = project
-    @desc = File.read(tmpl)
     tmpl = File.expand_path("markdown/vcc.md", __dir__)
+    @desc = File.read(tmpl)
   end
 
   def generate
     events = []
     vuln_events = []
-    Vcc.all.each do |vcc|
+    Vcc.joins(:vulnerability)
+       .where('vulnerabilities.project_id' => @project.id)
+       .each do |vcc|
       e = Event.new(
         style: style,
         title: "Vulnerability-contributing commit for #{vcc.vulnerability.cve}: #{vcc.commit.title}",

--- a/lib/event_generators/vulnerability_events.rb
+++ b/lib/event_generators/vulnerability_events.rb
@@ -1,7 +1,7 @@
 class VulnerabilityEvents
 
   def generate
-    Vulnerability.all.each do |v|
+    Vulnerability.where(project: @project).each do |v|
         e = Event.create!(
           style: style,
           date: v.announced,

--- a/lib/event_generators/vulnerability_events.rb
+++ b/lib/event_generators/vulnerability_events.rb
@@ -1,5 +1,9 @@
 class VulnerabilityEvents
 
+  def initialize(project)
+    @project = project
+  end
+
   def generate
     Vulnerability.where(project: @project).each do |v|
         e = Event.create!(

--- a/lib/event_generators/weekly_report_events.rb
+++ b/lib/event_generators/weekly_report_events.rb
@@ -3,10 +3,6 @@ require 'date'
 
 class WeeklyReportEvents
 
-  def initialize(project)
-    @project = project
-  end
-
   def cve_from_filename(f)
     f.match(/.*(?<cve>CVE-.+-.+)-weekly.json/)[:cve]
   end

--- a/lib/event_generators/weekly_report_events.rb
+++ b/lib/event_generators/weekly_report_events.rb
@@ -3,6 +3,10 @@ require 'date'
 
 class WeeklyReportEvents
 
+  def initialize(project)
+    @project = project
+  end
+
   def cve_from_filename(f)
     f.match(/.*(?<cve>CVE-.+-.+)-weekly.json/)[:cve]
   end

--- a/lib/taggers/DEPS_tagger.rb
+++ b/lib/taggers/DEPS_tagger.rb
@@ -1,6 +1,10 @@
 require_relative '../writing'
 class DEPSTagger
 
+  def initialize(project)
+    @project = project
+  end
+
   def create_tags
     @DEPS_tag = Tag.find_or_create_by!(
       name: 'DEPS file changed',
@@ -11,7 +15,10 @@ class DEPSTagger
   end
 
   def apply_tags
-    Vulnerability.joins(fixes: {commit: :filepaths}).where("filepaths.filepath = 'DEPS'").each do |v|
+    Vulnerability.joins([:project, fixes: {commit: :filepaths}])
+                 .where("filepaths.filepath = 'DEPS'")
+                 .where(project: @project)
+                 .each do |v|
       VulnerabilityTag.create!(
         vulnerability: v,
         tag: @DEPS_tag

--- a/lib/taggers/bounty_tagger.rb
+++ b/lib/taggers/bounty_tagger.rb
@@ -1,6 +1,11 @@
 require_relative '../writing'
 
 class BountyTagger
+
+  def initialize(project)
+    @project = project
+  end
+
   def create_tags
     @bounty_tag = Tag.find_or_create_by!(
       name: 'Bounty Awarded',
@@ -11,7 +16,7 @@ class BountyTagger
   end
 
   def apply_tags
-    Vulnerability.all.each do |v|
+    Vulnerability.where(project: @project).each do |v|
       if has_bounty?(v)
         VulnerabilityTag.create!(
           vulnerability: v,

--- a/lib/taggers/cwe_tagger.rb
+++ b/lib/taggers/cwe_tagger.rb
@@ -2,46 +2,8 @@ require 'csv'
 
 class CWETagger
 
-  def create_tags
-    Vulnerability.all.each do |v|
-      cwe = normalized_cwe_string(v.notes['CWE'])
-      if @tagged_cwes.key?(cwe)
-        Tag.find_or_create_by!(@tagged_cwes[cwe])
-      end
-    end
-  end
-
-  def apply_tags
-    vuln_tags = []
-    untagged = []
-    Vulnerability.all.each do |v|
-      if @tagged_cwes.key? normalized_cwe_string(v.notes['CWE'])
-        vuln_tags << VulnerabilityTag.new(
-          vulnerability: v,
-          tag: find_tag(v.notes['CWE']),
-          note: ''
-        )
-      else
-        puts "WARNING: Un-tagged CWE: #{v.notes['CWE']} in #{v.cve}" unless v.notes['CWE'].to_s.blank?
-        untagged << normalized_cwe_string(v.notes['CWE'])
-      end
-    end
-    VulnerabilityTag.import vuln_tags
-    # puts "Untagged, normalized: #{untagged.sort}"
-  end
-
-  # If people entered in text here, just take the number
-  # e.g. CWE-122 ==> 122
-  def normalized_cwe_string(cwe)
-    cwe.to_s.gsub(/[^0-9]/,'').to_i
-  end
-
-  def find_tag(cwe_str)
-    shortname = @tagged_cwes[normalized_cwe_string(cwe_str)][:shortname]
-    Tag.find_by(shortname: shortname)
-  end
-
-  def initialize
+  def initialize(project)
+    @project = project
     @tagged_cwes = {}
     CSV.foreach(Rails.root + "lib/taggers/resources/cwes.csv") do |fields|
       @tagged_cwes[fields[0].to_i] = {
@@ -63,6 +25,44 @@ class CWETagger
           EOS
       }
     end
+  end
+
+  def create_tags
+    Vulnerability.where(project: @project).each do |v|
+      cwe = normalized_cwe_string(v.notes['CWE'])
+      if @tagged_cwes.key?(cwe)
+        Tag.find_or_create_by!(@tagged_cwes[cwe])
+      end
+    end
+  end
+
+  def apply_tags
+    vuln_tags = []
+    untagged = []
+    Vulnerability.where(project: @project).each do |v|
+      if @tagged_cwes.key? normalized_cwe_string(v.notes['CWE'])
+        vuln_tags << VulnerabilityTag.new(
+          vulnerability: v,
+          tag: find_tag(v.notes['CWE']),
+          note: ''
+        )
+      else
+        puts "WARNING: Un-tagged CWE: #{v.notes['CWE']} in #{v.cve}" unless v.notes['CWE'].to_s.blank?
+        untagged << normalized_cwe_string(v.notes['CWE'])
+      end
+    end
+    VulnerabilityTag.import vuln_tags
+  end
+
+  # If people entered in text here, just take the number
+  # e.g. CWE-122 ==> 122
+  def normalized_cwe_string(cwe)
+    cwe.to_s.gsub(/[^0-9]/,'').to_i
+  end
+
+  def find_tag(cwe_str)
+    shortname = @tagged_cwes[normalized_cwe_string(cwe_str)][:shortname]
+    Tag.find_by(shortname: shortname)
   end
 
 end

--- a/lib/taggers/discovery_tagger.rb
+++ b/lib/taggers/discovery_tagger.rb
@@ -2,6 +2,10 @@ require_relative '../writing'
 
 class DiscoveryTagger
 
+  def initialize(project)
+    @project = project
+  end
+
   def create_tags
     @automated_tag = Tag.find_by(shortname: 'automated')
     if not @automated_tag
@@ -55,7 +59,7 @@ class DiscoveryTagger
   end
 
   def apply_tags
-    Vulnerability.all.each do |v|
+    Vulnerability.where(project: @project).each do |v|
       findTags(v)
       @tags.each do |t|
         VulnerabilityTag.create!(

--- a/lib/taggers/error_of_omission_tagger.rb
+++ b/lib/taggers/error_of_omission_tagger.rb
@@ -1,5 +1,10 @@
 require_relative '../writing'
 class ErrorOfOmissionTagger
+
+  def initialize(project)
+    @project = project
+  end
+
   def create_tags
     @tag = Tag.find_or_create_by!(
       name: 'Lesson: Error of Omission',

--- a/lib/taggers/error_of_omission_tagger.rb
+++ b/lib/taggers/error_of_omission_tagger.rb
@@ -16,12 +16,14 @@ class ErrorOfOmissionTagger
 
   def apply_tags
     # to_number is a postgresql thing that formats the number. '9' is a format string
-    errors_of_omission = Fix.where("
-      to_number(notes->>'deletions','99999') = 0
+    errors_of_omission = Fix.joins(:vulnerability)
+                            .where('vulnerabilities.project_id' => @project.id)
+                            .where("
+      to_number(fixes.notes->>'deletions','99999') = 0
       OR
-      ( to_number(notes->>'deletions','9') > 0 AND
-        ( to_number(notes->>'insertions','99999')
-          / to_number(notes->>'deletions','99999') ) > 10.0
+      ( to_number(fixes.notes->>'deletions','9') > 0 AND
+        ( to_number(fixes.notes->>'insertions','99999')
+          / to_number(fixes.notes->>'deletions','99999') ) > 10.0
       )
     ")
     errors_of_omission.each do |fix|

--- a/lib/taggers/fix_tagger.rb
+++ b/lib/taggers/fix_tagger.rb
@@ -29,8 +29,10 @@ class FixTagger
               FROM commit_filepaths
                 INNER JOIN fixes ON commit_filepaths.commit_id = fixes.commit_id
                 INNER JOIN vulnerabilities ON fixes.vulnerability_id = vulnerabilities.id
+              WHERE vulnerabilities.project_id = '#{@project.id}'
               GROUP BY vulnerabilities.id,fixes.commit_id
               HAVING SUM(total_churn) > 100;"
+    # no, sql injection isn't possible here because project.id can only be an int.
     results = ActiveRecord::Base.connection.execute(query)
 
     results.each do |r|
@@ -49,6 +51,7 @@ class FixTagger
                FROM commit_filepaths
                     INNER JOIN fixes ON commit_filepaths.commit_id = fixes.commit_id
                     INNER JOIN vulnerabilities ON fixes.vulnerability_id = vulnerabilities.id
+              WHERE vulnerabilities.project_id = '#{@project.id}'
               GROUP BY vulnerabilities.id,fixes.commit_id
               HAVING SUM(total_churn) < 20;"
     results = ActiveRecord::Base.connection.execute(query)

--- a/lib/taggers/fix_tagger.rb
+++ b/lib/taggers/fix_tagger.rb
@@ -1,6 +1,10 @@
 require_relative '../writing'
 class FixTagger
 
+  def initialize(project)
+    @project = project
+  end
+
   def create_tags
     @big_fix_tag = Tag.find_or_create_by(
       name: 'Fix: Big',

--- a/lib/taggers/language_tagger.rb
+++ b/lib/taggers/language_tagger.rb
@@ -1,6 +1,11 @@
 require 'set'
 require_relative '../writing'
 class LanguageTagger
+
+  def initialize(project)
+    @project = project
+  end
+
   def create_tags
     @c_tag = Tag.find_or_create_by!(
         name: 'Language: C',
@@ -39,7 +44,7 @@ class LanguageTagger
   end
 
   def apply_tags
-    Vulnerability.all.each do |v|
+    Vulnerability.where(project: @project).each do |v|
       findTags(v)
       @tags.each do |t|
         if t

--- a/lib/taggers/lessons_tagger.rb
+++ b/lib/taggers/lessons_tagger.rb
@@ -1,6 +1,10 @@
 require_relative '../writing'
 class LessonsTagger
 
+  def initialize(project)
+    @project = project
+  end
+
   def create_tags
     @lessons = [ 'defense_in_depth', 'least_privilege', 'frameworks_are_optional', 'native_wrappers', 'distrust_input', 'security_by_obscurity', 'serial_killer', 'environment_variables', 'secure_by_default', 'yagni', 'complex_inputs']
     @tags = Hash.new
@@ -109,7 +113,7 @@ class LessonsTagger
   end
 
   def apply_tags
-    Vulnerability.all.each do |v|
+    Vulnerability.where(project: @project).each do |v|
       findTags(v)
       @found_tags.each do |t|
         VulnerabilityTag.create!(

--- a/lib/taggers/long_running_tagger.rb
+++ b/lib/taggers/long_running_tagger.rb
@@ -21,7 +21,10 @@ class LongRunningTagger
               INNER JOIN vccs AS vcc ON vcc.vulnerability_id = v.id
               INNER JOIN commits AS commit1 ON commit1.id = vcc.commit_id
               INNER JOIN commits AS commit2 ON commit2.id = fix.commit_id
-              WHERE (commit2.date_created - commit1.date_created) > '2 years'"
+              WHERE (commit2.date_created - commit1.date_created) > '2 years'
+              AND v.project_id = '#{@project.id}'
+            "
+
     results = ActiveRecord::Base.connection.execute(query)
     results.each do |v|
       t = VulnerabilityTag.new(

--- a/lib/taggers/long_running_tagger.rb
+++ b/lib/taggers/long_running_tagger.rb
@@ -1,6 +1,10 @@
 require_relative '../writing'
 class LongRunningTagger
 
+  def initialize(project)
+    @project = project
+  end
+
   def create_tags
     @Long_Running_Tag = Tag.find_or_create_by!(
       name: 'Long Running Vulnerability',

--- a/lib/taggers/origin_tagger.rb
+++ b/lib/taggers/origin_tagger.rb
@@ -3,6 +3,10 @@ require_relative '../writing'
 
 class OriginTagger
 
+  def initialize(project)
+    @project = project
+  end
+
   def create_tags
     @Origin_tag = Tag.find_or_create_by!(
       name: 'Origin Vulnerability',
@@ -28,7 +32,10 @@ class OriginTagger
     y.each do |commit|
       commits << commit["commit"]
     end
-    vulns = Vulnerability.joins(vccs: :commit).where(make_where(commits))
+    vulns = Vulnerability
+              .joins([:project, vccs: :commit])
+              .where(project: @project)
+              .where(make_where(commits))
     vulns.each do |v|
       t = VulnerabilityTag.new(
         vulnerability: v,

--- a/lib/taggers/project_tagger.rb
+++ b/lib/taggers/project_tagger.rb
@@ -1,5 +1,9 @@
 class ProjectTagger
 
+  def initialize(project)
+    @project = project
+  end
+
   def initialize(repo_dir, project)
     @repo_dir = repo_dir
     @project = project

--- a/lib/taggers/subsystem_tagger.rb
+++ b/lib/taggers/subsystem_tagger.rb
@@ -1,8 +1,12 @@
 require_relative '../writing'
 class SubsystemTagger
 
+  def initialize(project)
+    @project = project
+  end
+
   def create_tags
-    Vulnerability.all.each do |v|
+    Vulnerability.where(project: @project).each do |v|
       name = normalized v.notes.dig('subsystem', 'name')
       unless name.empty?
         @tag = Tag.find_by(shortname: shortname(name))
@@ -23,7 +27,7 @@ class SubsystemTagger
   end
 
   def apply_tags
-    Vulnerability.all.each do |v|
+    Vulnerability.where(project: @project).each do |v|
       name = normalized v.notes.dig('subsystem', 'name')
       unless name.empty?
         t = Tag.find_by(shortname: shortname(name))

--- a/lib/taggers/unit_test_tagger.rb
+++ b/lib/taggers/unit_test_tagger.rb
@@ -1,6 +1,10 @@
 require_relative '../writing'
 class UnitTestTagger
 
+  def initialize(project)
+    @project = project
+  end
+
   def create_tags
     @escaped_tag = Tag.find_by(shortname: 'escaped')
     if not @escaped_tag
@@ -34,7 +38,7 @@ class UnitTestTagger
   end
 
   def apply_tags
-    Vulnerability.all.each do |v|
+    Vulnerability.where(project: @project).each do |v|
       findTags(v)
       @tags.each do |t|
         VulnerabilityTag.create!(

--- a/lib/tasks/chromium.rake
+++ b/lib/tasks/chromium.rake
@@ -88,6 +88,7 @@ namespace :data do
 
     desc 'Generate event models'
     task :events => :environment do
+      project = Project.find_by(subdomain: 'chromium')
       [
         SimilarEvents,
         VulnerabilityEvents,
@@ -97,7 +98,7 @@ namespace :data do
         BountyEvents,
       ].each do |generator|
         logger.info "Generating #{generator.to_s.tableize.humanize.downcase}"
-        generator.new.generate
+        generator.new(project).generate
       end
       logger.info "Generating weekly report events and tags"
       WeeklyReportEvents.new.generate(repo_dir)
@@ -105,6 +106,7 @@ namespace :data do
 
     desc 'Generate and apply tags'
     task :tags => :environment do
+      project = Project.find_by(subdomain: 'chromium')
       [
         LongRunningTagger,
         BountyTagger,
@@ -120,15 +122,14 @@ namespace :data do
         UnitTestTagger
       ].each do |tagger|
         logger.info "Tagging with #{tagger}"
-        t = tagger.new
+        t = tagger.new(project)
         t.create_tags
         t.apply_tags
       end
-      orig = OriginTagger.new
+      orig = OriginTagger.new(project)
       orig.create_tags
       orig.apply_tags(repo_dir)
 
-      project = Project.find_by(subdomain: 'chromium')
       project_tagger = ProjectTagger.new(repo_dir, project)
       project_tagger.create_tags
       project_tagger.apply_tags

--- a/lib/tasks/httpd.rake
+++ b/lib/tasks/httpd.rake
@@ -73,6 +73,7 @@ namespace :data do
 
     desc 'Generate event models'
     task :events => :environment do
+      project = Project.find_by(subdomain: 'httpd')
       [
         SimilarEvents,
         VulnerabilityEvents,
@@ -82,7 +83,7 @@ namespace :data do
         BountyEvents,
       ].each do |generator|
         logger.info "Generating #{generator.to_s.tableize.humanize.downcase}"
-        generator.new.generate
+        generator.new(project).generate
       end
       logger.info "Generating weekly report events and tags"
       WeeklyReportEvents.new.generate(repo_dir)
@@ -90,6 +91,7 @@ namespace :data do
 
     desc 'Generate and apply tags'
     task :tags => :environment do
+      project = Project.find_by(subdomain: 'httpd')
       [
         LongRunningTagger,
         BountyTagger,
@@ -104,11 +106,11 @@ namespace :data do
         UnitTestTagger
       ].each do |tagger|
         logger.info "Tagging with #{tagger}"
-        t = tagger.new
+        t = tagger.new(project)
         t.create_tags
         t.apply_tags
       end
-      orig = OriginTagger.new
+      orig = OriginTagger.new(project)
       orig.create_tags
       orig.apply_tags(repo_dir)
 

--- a/test/lib/event_generators/all_vulnerability_events_test.rb
+++ b/test/lib/event_generators/all_vulnerability_events_test.rb
@@ -1,14 +1,16 @@
 require 'test_helper'
+require 'writing'
 require_all 'lib/event_generators/*.rb'
 
 class AllLulnerabilityEventsTest < ActiveSupport::TestCase
 
   setup do
-    VulnerabilityEvents.new.generate
-    FixEvents.new.generate
-    VccEvents.new.generate
-    ReleaseEvents.new.generate
-    BountyEvents.new.generate
+    p = projects(:one)
+    VulnerabilityEvents.new(p).generate
+    FixEvents.new(p).generate
+    VccEvents.new(p).generate
+    ReleaseEvents.new(p).generate
+    BountyEvents.new(p).generate
   end
 
   test 'get all vulnerability events' do

--- a/test/lib/event_generators/bounty_events_test.rb
+++ b/test/lib/event_generators/bounty_events_test.rb
@@ -5,7 +5,8 @@ require 'writing'
 class BountyEventsTest < ActiveSupport::TestCase
 
   test 'bounty events created for all vulns' do
-    BountyEvents.new.generate
+    p = projects(:one)
+    BountyEvents.new(p).generate
     expected = [
       "Bounty awarded for CVE-2011-3092"
     ]

--- a/test/lib/event_generators/fix_events_test.rb
+++ b/test/lib/event_generators/fix_events_test.rb
@@ -1,11 +1,12 @@
 require 'test_helper'
 require 'event_generators/fix_events'
+require 'writing'
 
 class FixEventsTest < ActiveSupport::TestCase
 
   test 'commit events created for all vulns' do
-    FixEvents.new.generate
-    # byebug
+    p = projects(:one)
+    FixEvents.new(p).generate
     actual = Event.where(title: "Fix for CVE-2011-3092: Strip CRs from *.in files to allow building from webkit.org").
                    count
     assert_equal 1, actual

--- a/test/lib/event_generators/similar_events_test.rb
+++ b/test/lib/event_generators/similar_events_test.rb
@@ -1,16 +1,16 @@
 require 'test_helper'
 require 'event_generators/similar_events'
+require 'writing'
 
 class SimilarEventsTest < ActiveSupport::TestCase
 
   test 'similar events created for vulns' do
-    # level = Rails.logger.level
-    Rails.logger.level = 0
-    SimilarEvents.new.generate
+    p = projects(:one)
+    SimilarEvents.new(p).generate
     expected = [
       "Similar vulnerability: CVE-2011-3092 is also in this/is/a/test",
-      "Similar vulnerability: CVE-2013-2878 has the same CWE 119",
-      "Similar vulnerability: CVE-2016-1676 has the same CWE 119",
+      "Similar vulnerability: CVE-2013-2878 has the same CWE",
+      "Similar vulnerability: CVE-2016-1676 has the same CWE",
       "Similar vulnerability: CVE-2016-1676 is also in this/is/a/test"
     ]
 
@@ -18,7 +18,6 @@ class SimilarEventsTest < ActiveSupport::TestCase
                    map{ |e| e.description }.sort
 
     assert_equal expected, actual
-    # Rails.logger.level = level
   end
 
 end

--- a/test/lib/event_generators/vcc_events_test.rb
+++ b/test/lib/event_generators/vcc_events_test.rb
@@ -1,10 +1,12 @@
 require 'test_helper'
 require 'event_generators/vcc_events'
+require 'writing'
 
 class VccEventsTest < ActiveSupport::TestCase
 
   test 'vcc events created for all vccs' do
-    VccEvents.new.generate
+    p = projects(:one)
+    VccEvents.new(p).generate
     expected = [
       "Vulnerability-contributing commit for CVE-2011-3092: Remove empty unused directories from src/webkit.",
       "Vulnerability-contributing commit for CVE-2011-3092: WebKit merge 39606:39660 Review URL: http://codereview.chromium.org/17239",

--- a/test/lib/event_generators/vulnerability_events_test.rb
+++ b/test/lib/event_generators/vulnerability_events_test.rb
@@ -1,10 +1,12 @@
 require 'test_helper'
 require 'event_generators/vulnerability_events'
+require 'writing'
 
 class VulnerabilityEventsTest < ActiveSupport::TestCase
 
   setup do
-    VulnerabilityEvents.new.generate
+    p = projects(:one)
+    VulnerabilityEvents.new(p).generate
   end
 
   test 'vuln announcement events created for all vulns' do

--- a/test/lib/taggers/DEPS_tag_test.rb
+++ b/test/lib/taggers/DEPS_tag_test.rb
@@ -2,14 +2,17 @@ require 'test_helper'
 require 'taggers/DEPS_tagger'
 
 class DEPSTagTest < ActiveSupport::TestCase
+
   test 'lesson tags created' do
-    t = DEPSTagger.new
+    p = projects(:one)
+    t = DEPSTagger.new(p)
     t.create_tags
     assert_equal(1, Tag.where(shortname: 'DEPS').size)
   end
 
   test 'DEPS tag not duplicated' do
-    t = DEPSTagger.new
+    p = projects(:one)
+    t = DEPSTagger.new(p)
     tag_count_before = Tag.all.size
     if Tag.exists?(shortname: 'DEPS')
       tag_count_after = Tag.all.size
@@ -18,7 +21,8 @@ class DEPSTagTest < ActiveSupport::TestCase
   end
 
   test 'DEPS tag applied' do
-    t = DEPSTagger.new
+    p = projects(:one)
+    t = DEPSTagger.new(p)
     t.create_tags
     t.apply_tags
     tag = Tag.find_by(shortname: 'DEPS')

--- a/test/lib/taggers/language_tag_test.rb
+++ b/test/lib/taggers/language_tag_test.rb
@@ -3,7 +3,7 @@ require 'taggers/language_tagger'
 
 class LanguageTagTest < ActiveSupport::TestCase
   test 'language tags created' do
-    t = LanguageTagger.new
+    t = LanguageTagger.new(projects(:one))
     t.create_tags
     assert_equal(1, Tag.where(shortname: 'C').size)
     assert_equal(1, Tag.where(shortname: 'C++').size)
@@ -13,7 +13,7 @@ class LanguageTagTest < ActiveSupport::TestCase
   end
 
   test 'language tags not duplicated' do
-    t = LanguageTagger.new
+    t = LanguageTagger.new(projects(:one))
     tag_count_before = Tag.all.size
     if Tag.exists?(shortname: 'C') and Tag.exists?(shortname: 'C++') and Tag.exists?(shortname: 'Java') and Tag.exists?(shortname: 'JS') and Tag.exists?(shortname: 'Python')
       t.create_tags
@@ -23,7 +23,7 @@ class LanguageTagTest < ActiveSupport::TestCase
   end
 
   test 'C tag applied' do
-    t = LanguageTagger.new
+    t = LanguageTagger.new(projects(:one))
     t.create_tags
     t.apply_tags
     tag = Tag.find_by(shortname: 'C')
@@ -34,7 +34,7 @@ class LanguageTagTest < ActiveSupport::TestCase
   end
 
   test 'C++ tag applied' do
-    t = LanguageTagger.new
+    t = LanguageTagger.new(projects(:one))
     t.create_tags
     t.apply_tags
     tag = Tag.find_by(shortname: 'C++')
@@ -45,7 +45,7 @@ class LanguageTagTest < ActiveSupport::TestCase
   end
 
   test 'Java tag applied' do
-    t = LanguageTagger.new
+    t = LanguageTagger.new(projects(:one))
     t.create_tags
     t.apply_tags
     tag = Tag.find_by(shortname: 'Java')
@@ -56,7 +56,7 @@ class LanguageTagTest < ActiveSupport::TestCase
   end
 
   test 'Javascript tag applied' do
-    t = LanguageTagger.new
+    t = LanguageTagger.new(projects(:one))
     t.create_tags
     t.apply_tags
     tag = Tag.find_by(shortname: 'JS')
@@ -67,7 +67,7 @@ class LanguageTagTest < ActiveSupport::TestCase
   end
 
   test 'Python tag applied' do
-    t = LanguageTagger.new
+    t = LanguageTagger.new(projects(:one))
     t.create_tags
     t.apply_tags
     tag = Tag.find_by(shortname: 'Python')

--- a/test/lib/taggers/lessons_tag_test.rb
+++ b/test/lib/taggers/lessons_tag_test.rb
@@ -3,7 +3,7 @@ require 'taggers/lessons_tagger'
 
 class LessonsTagTest < ActiveSupport::TestCase
   test 'lesson tags created' do
-    t = LessonsTagger.new
+    t = LessonsTagger.new(projects(:one))
     t.create_tags
     assert_equal(1, Tag.where(shortname: 'defense').size)
     assert_equal(1, Tag.where(shortname: 'least privilege').size)
@@ -19,7 +19,7 @@ class LessonsTagTest < ActiveSupport::TestCase
   end
 
   test 'lessons tags not duplicated' do
-    t = LessonsTagger.new
+    t = LessonsTagger.new(projects(:one))
     tag_count_before = Tag.all.size
     if Tag.exists?(shortname: 'defense') and Tag.exists?(shortname: 'least privilege') and Tag.exists?(shortname: 'optional frameworks') and Tag.exists?(shortname: 'wrappers') and Tag.exists?(shortname: 'distrust input') and Tag.exists?(shortname: 'obscurity') and Tag.exists?(shortname: 'serial') and Tag.exists?(shortname: 'environment') and Tag.exists?(shortname: 'secure by default') and Tag.exists?(shortname: 'yagni') and Tag.exists?(shortname: 'complex inputs')
       t.create_tags
@@ -29,7 +29,7 @@ class LessonsTagTest < ActiveSupport::TestCase
   end
 
   test 'complex inputs tag applied' do
-    t = LessonsTagger.new
+    t = LessonsTagger.new(projects(:one))
     t.create_tags
     t.apply_tags
     tag = Tag.find_by(shortname: 'complex inputs')

--- a/test/lib/taggers/unittest_tag_test.rb
+++ b/test/lib/taggers/unittest_tag_test.rb
@@ -4,7 +4,7 @@ require 'taggers/unit_test_tagger'
 class UnitTagTest < ActiveSupport::TestCase
 
   test 'unit test tags created' do
-    t = UnitTestTagger.new
+    t = UnitTestTagger.new(projects(:one))
     t.create_tags
     assert_equal(1, Tag.where(shortname: 'escaped').size)
     assert_equal(1, Tag.where(shortname: 'lacked').size)
@@ -12,7 +12,7 @@ class UnitTagTest < ActiveSupport::TestCase
   end
 
   test 'unit test tags not duplicated' do
-    t = UnitTestTagger.new
+    t = UnitTestTagger.new(projects(:one))
     tag_count_before = Tag.all.size
     if Tag.exists?(shortname: 'escaped') and Tag.exists?(shortname: 'lacked') and Tag.exists?(shortname: 'untested')
       t.create_tags
@@ -22,7 +22,7 @@ class UnitTagTest < ActiveSupport::TestCase
   end
 
   test 'escape tag applied' do
-    t = UnitTestTagger.new
+    t = UnitTestTagger.new(projects(:one))
     t.create_tags
     t.apply_tags
     tag = Tag.find_by(shortname: 'escaped')
@@ -33,7 +33,7 @@ class UnitTagTest < ActiveSupport::TestCase
   end
 
   test 'lacked tag applied' do
-    t = UnitTestTagger.new
+    t = UnitTestTagger.new(projects(:one))
     t.create_tags
     t.apply_tags
     tag = Tag.find_by(shortname: 'lacked')
@@ -44,7 +44,7 @@ class UnitTagTest < ActiveSupport::TestCase
   end
 
   test 'untested tag applied' do
-    t = UnitTestTagger.new
+    t = UnitTestTagger.new(projects(:one))
     t.create_tags
     t.apply_tags
     tag = Tag.find_by(shortname: 'untested')


### PR DESCRIPTION
Per #504, taggers and event generators should have the project as a parameter, since we load each project in individually. 

