### PR TITLE
Fix sorting by a date column on two pages

### DIFF
--- a/app/assets/javascripts/developers/show.js
+++ b/app/assets/javascripts/developers/show.js
@@ -142,22 +142,7 @@ $(document).ready( function() {
                     }
                   },
                   { title: 'Date Created', data: 'date_created', defaultContent: 'Unknown',
-                    render: function(data, type) {
-                      if (type === 'display') {
-                        // Display dates in a nice format.
-                        return moment(data).format('MMMM DD, YYYY, h:mm a');
-                      } else if (type === 'filter') {
-                        // Allow for the filtering of dates in a variety of formats.
-                        // The type is "filter" when the search bar is used.
-                        let currentDate = moment(data);
-                        let long_display = currentDate.format('MMMM DD, YYYY, h:mm a');
-                        let short_display = currentDate.format("MM/DD/YYYY");
-                        return data + " " + long_display + " " + short_display;
-                      } else {
-                        // Sort dates without any special formatting.
-                        return data;
-                      }
-                    }
+                    render: (data, type, row) => renderDateColumn(data, type, row, 'MMMM DD, YYYY, h:mm a', false)
                   },
                   { title: 'Lines Changed', data: 'notes.churn', defaultContent: 'Unknown' },
                   { title: 'Abbreviated Commit Message', data: 'message', defaultContent: 'None',

--- a/app/assets/javascripts/developers/show.js
+++ b/app/assets/javascripts/developers/show.js
@@ -145,12 +145,12 @@ $(document).ready( function() {
                     render: function(data, type) {
                       if (type === 'display') {
                         // Display dates in a nice format.
-                        return moment(data).format('MMMM Do YYYY, h:mm a');
+                        return moment(data).format('MMMM DD, YYYY, h:mm a');
                       } else if (type === 'filter') {
                         // Allow for the filtering of dates in a variety of formats.
                         // The type is "filter" when the search bar is used.
                         let currentDate = moment(data);
-                        let long_display = currentDate.format('MMMM Do YYYY, h:mm a');
+                        let long_display = currentDate.format('MMMM DD, YYYY, h:mm a');
                         let short_display = currentDate.format("MM/DD/YYYY");
                         return data + " " + long_display + " " + short_display;
                       } else {

--- a/app/assets/javascripts/global/dateColumn.js
+++ b/app/assets/javascripts/global/dateColumn.js
@@ -1,0 +1,20 @@
+function renderDateColumn(data, type, row, displayFormat, isLink) {
+  if (type === 'display') {
+    // Display dates in a nice format.
+    if (isLink) {
+      return renderAsLink(moment(data).format(displayFormat), row);
+    } else {
+      return moment(data).format(displayFormat);
+    }
+  } else if (type === 'filter') {
+    // Allow for the filtering of dates in a variety of formats.
+    // The type is "filter" when the search bar is used.
+    let currentDate = moment(data);
+    let longDisplay = currentDate.format(displayFormat);
+    let shortDisplay = currentDate.format("MM/DD/YYYY");
+    return data + " " + longDisplay + " " + shortDisplay;
+  } else {
+    // Sort dates without any special formatting.
+    return data;
+  }
+}

--- a/app/assets/javascripts/global/vulnerabilitiesTable.js
+++ b/app/assets/javascripts/global/vulnerabilitiesTable.js
@@ -22,23 +22,7 @@ function columnsInfo(){
         defaultContent: '',
         class:'text-center',
         responsivePriority: 5,
-        render: function(data, type, row) {
-          //return renderAsLink(moment(data).format('MMMM DD, YYYY'), row);
-          if (type === 'display') {
-            // Display dates in a nice format.
-            return renderAsLink(moment(data).format('MMMM DD, YYYY'), row);
-          } else if (type === 'filter') {
-            // Allow for the filtering of dates in a variety of formats.
-            // The type is "filter" when the search bar is used.
-            let currentDate = moment(data);
-            let long_display = currentDate.format('MMMM DD, YYYY');
-            let short_display = currentDate.format("MM/DD/YYYY");
-            return data + " " + long_display + " " + short_display;
-          } else {
-            // Sort dates without any special formatting.
-            return data;
-          }
-        }
+        render: (data, type, row) => renderDateColumn(data, type, row, 'MMMM DD, YYYY', true)
       },
       {
         title: '<i class="vhp-icon-upvote"></i>',

--- a/app/assets/javascripts/global/vulnerabilitiesTable.js
+++ b/app/assets/javascripts/global/vulnerabilitiesTable.js
@@ -23,7 +23,21 @@ function columnsInfo(){
         class:'text-center',
         responsivePriority: 5,
         render: function(data, type, row) {
-          return renderAsLink(moment(data).format('MMMM DD, YYYY'), row);
+          //return renderAsLink(moment(data).format('MMMM DD, YYYY'), row);
+          if (type === 'display') {
+            // Display dates in a nice format.
+            return renderAsLink(moment(data).format('MMMM DD, YYYY'), row);
+          } else if (type === 'filter') {
+            // Allow for the filtering of dates in a variety of formats.
+            // The type is "filter" when the search bar is used.
+            let currentDate = moment(data);
+            let long_display = currentDate.format('MMMM DD, YYYY');
+            let short_display = currentDate.format("MM/DD/YYYY");
+            return data + " " + long_display + " " + short_display;
+          } else {
+            // Sort dates without any special formatting.
+            return data;
+          }
         }
       },
       {

--- a/app/assets/javascripts/tags/show.js
+++ b/app/assets/javascripts/tags/show.js
@@ -31,23 +31,7 @@ function columnsInfo() {
       defaultContent: '',
       class: 'text-center',
       responsivePriority: 5,
-      render: function(data, type, row) {
-        //return renderAsLink(moment(data).format('MMMM DD, YYYY'), row);
-        if (type === 'display') {
-          // Display dates in a nice format.
-          return renderAsLink(moment(data).format('MMMM DD, YYYY'), row);
-        } else if (type === 'filter') {
-          // Allow for the filtering of dates in a variety of formats.
-          // The type is "filter" when the search bar is used.
-          let currentDate = moment(data);
-          let long_display = currentDate.format('MMMM DD, YYYY');
-          let short_display = currentDate.format("MM/DD/YYYY");
-          return data + " " + long_display + " " + short_display;
-        } else {
-          // Sort dates without any special formatting.
-          return data;
-        }
-      }
+      render: (data, type, row) => renderDateColumn(data, type, row, 'MMMM DD, YYYY', true)
     },
     {
       title: 'Upvotes',

--- a/app/assets/javascripts/tags/show.js
+++ b/app/assets/javascripts/tags/show.js
@@ -31,7 +31,23 @@ function columnsInfo() {
       defaultContent: '',
       class: 'text-center',
       responsivePriority: 5,
-      render: (data, type, row) => renderAsLink(moment(data).format('MMMM DD, YYYY'), row)
+      render: function(data, type, row) {
+        //return renderAsLink(moment(data).format('MMMM DD, YYYY'), row);
+        if (type === 'display') {
+          // Display dates in a nice format.
+          return renderAsLink(moment(data).format('MMMM DD, YYYY'), row);
+        } else if (type === 'filter') {
+          // Allow for the filtering of dates in a variety of formats.
+          // The type is "filter" when the search bar is used.
+          let currentDate = moment(data);
+          let long_display = currentDate.format('MMMM DD, YYYY');
+          let short_display = currentDate.format("MM/DD/YYYY");
+          return data + " " + long_display + " " + short_display;
+        } else {
+          // Sort dates without any special formatting.
+          return data;
+        }
+      }
     },
     {
       title: 'Upvotes',


### PR DESCRIPTION
I'm not a big fan of how much I had to copy/paste the code for this. Depending on the page, the date format might be different. This definitely feels like a scenario where a single function with an argument of the date format could be used, but I'm not sure where that function would be defined. Thoughts? 

Other than that, it's ready to be merged.

**Commit Message:**
The Announced column on tags#show and the Date column on
vulnerabilities#index both sort correctly now based on chronology
rather than the alphabet.

I updated the format of the Date Created column on developers#show
to be more consistent with the rest of the site.