### PR TITLE
Events in timeline now display on page load (#514)

### DIFF
--- a/app/assets/javascripts/timeline/timelines.js
+++ b/app/assets/javascripts/timeline/timelines.js
@@ -140,14 +140,14 @@ function timelines(settings) {
       var self = this;
       this.events.forEach(function(e) {
         if (self.shouldDrawToggle(e)) {
-          if (!self.validTypes.includes(e.type)) {
-            self.validTypes.push(e.type);
+          if (!self.validTypes.includes(e.event_type)) {
+            self.validTypes.push(e.event_type);
           }
         }
 
-        if (!self.inactiveToggles.includes(e.type))
+        if (!self.inactiveToggles.includes(e.event_type))
         {
-          self.activeToggles.push(e.type);
+          self.activeToggles.push(e.event_type);
         }
       });
     };
@@ -240,7 +240,7 @@ function timelines(settings) {
     this.generateFilters = function() {
       var self = this;
       reducer = function(hash, e) { // uniq-ify all event types, keeping colors
-        if (self.validTypes.includes(e.type)) {
+        if (self.validTypes.includes(e.event_type)) {
           hash[e.event_type.replace(' ','_')] = e.style_color;
         }
         return hash;


### PR DESCRIPTION
Just had to update the references of e.type to e.event_type. I'm not sure when that changed, but the other references in the file had already been updated.