### PR TITLE
gzip all http responses

### DIFF
--- a/config/initializers/gzip_responses.rb
+++ b/config/initializers/gzip_responses.rb
@@ -1,0 +1,3 @@
+# Based on article found here: https://www.schneems.com/2017/11/08/80-smaller-rails-footprint-with-rack-deflate/
+
+Rails.application.config.middleware.insert_after ActionDispatch::Static, Rack::Deflater


### PR DESCRIPTION
One easy way to speed things up is to run gzip over everything. The computation time is much faster than sending more packets. And it looks like gzipping is pretty effective here in terms of size. 