### PR TITLE
remove jbuilder cruft

### DIFF
--- a/app/views/commits/_commit.json.jbuilder
+++ b/app/views/commits/_commit.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! commit, :id, :commit_hash, :author_email, :notes, :created_at
-json.url commit_url(commit, format: :json)

--- a/app/views/commits/index.json.jbuilder
+++ b/app/views/commits/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @commits, partial: 'commits/commit', as: :commit

--- a/app/views/commits/show.json.jbuilder
+++ b/app/views/commits/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "commits/commit", commit: @commit

--- a/app/views/developers/_developer.json.jbuilder
+++ b/app/views/developers/_developer.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! developer, :id, :email
-json.url developer_url(developer, format: :json)

--- a/app/views/developers/index.json.jbuilder
+++ b/app/views/developers/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @developers, partial: 'developers/developer', as: :developer

--- a/app/views/developers/show.json.jbuilder
+++ b/app/views/developers/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "developers/developer", developer: @developer

--- a/app/views/filepaths/_filepaths.json.jbuilder
+++ b/app/views/filepaths/_filepaths.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! filepath, :id, :filepath, :note
-json.url filepaths_url(filepath, format: :json)

--- a/app/views/filepaths/index.json.jbuilder
+++ b/app/views/filepaths/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @filepaths, partial: 'filepaths/filepath', as: :filepath

--- a/app/views/filepaths/show.json.jbuilder
+++ b/app/views/filepaths/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "filepaths/filepath", filepath: @filepath

--- a/app/views/vulnerabilities/_vulnerability.json.jbuilder
+++ b/app/views/vulnerabilities/_vulnerability.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! vulnerability, :id, :CVE, :notes
-json.url vulnerability_url(vulnerability, format: :json)

--- a/app/views/vulnerabilities/index.json.jbuilder
+++ b/app/views/vulnerabilities/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @vulnerabilities, partial: 'vulnerabilities/vulnerability', as: :vulnerability

--- a/app/views/vulnerabilities/show.json.jbuilder
+++ b/app/views/vulnerabilities/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "vulnerabilities/vulnerability", vulnerability: @vulnerability


### PR DESCRIPTION
The jbuilder files were part of the original scaffolding. We've got our API design working great as-is, so I don't think we need these files anymore. In working on #578 I even ran into places where these jbuilders were being called so now they're problematic.