### PR TITLE
fix date parsing browser issue

### DIFF
--- a/app/assets/javascripts/timeline/timelines.js
+++ b/app/assets/javascripts/timeline/timelines.js
@@ -366,7 +366,7 @@ function timelines(settings) {
      * Calculates the range between two dates
      * @param a - the start date
      * @param b - the end date
-     * @returns {number} the difference (absolute) between the dates
+     * @returns {number} the difference (absolute) between the dates in days
      */
     this.calculateDateRange = function(a, b) {
         var utc1 = Date.UTC(a.getFullYear(), a.getMonth(), a.getDate());

--- a/app/assets/javascripts/vulnerabilities/show.js
+++ b/app/assets/javascripts/vulnerabilities/show.js
@@ -119,15 +119,18 @@ $( document ).ready( function() {
   var events = []; // global to the page for resizing
 
   $.ajax({
-    url: "/api/vulnerabilities/" + vulnerability_id + "/events",
+    url: `/api/vulnerabilities/${vulnerability_id}/events`,
     dataType: 'json',
   }).done(function(vuln_events){
     $('#vtimeline_loading').remove();
     populateVTimeline(vuln_events);
   }).done(function(vuln_events) {
     for(let e of vuln_events) {
-        e.date = new Date(e.date); //Rails AR date string to JS date object
-        events.push(e); //set to global events
+      // Here we convert Rails AR date string to JS date object
+      // using moment.js - different browsers treat time parsing differently
+      // so we need to specify the date format string.
+      e.date = new Date(moment(e.date,'YYYY-MM-DD hh:mm:ss Z'));
+      events.push(e); //set to global events
     }
     $('#htimeline-loading').hide();
     populateHTimeline(hTimeline, events);


### PR DESCRIPTION
This gets the timelines back to working on Firefox. I have not been able to reproduced the "missing timlines" issue reliably, however.