### PR TITLE
Fix vhp-art-* image displays for Firefox

### DIFF
--- a/app/assets/javascripts/global/articleListing.js
+++ b/app/assets/javascripts/global/articleListing.js
@@ -24,7 +24,7 @@ function articleListing(jsonData, container = '#article-listing') {
   let blurbArts = $('.blurb-art');
   for (let i = 0; i < jsonData.length; i++) {
     let article = jsonData[i];
-    $(blurbArts[i]).html(`<img class="vhp-art-${article.art}"/>`);
+    $(blurbArts[i]).html(`<div class="vhp-art-${article.art}"/>`);
     blurbs[i].innerHTML = `<h3>${article.title}</h3><p>${article.blurb}</p>`;
   }
 }
@@ -52,8 +52,7 @@ function articleListingOneSize(jsonData, container = '#article-listing-same') {
   let blurbArts = $('.blurb-art');
   for (let i = 0; i < jsonData.length; i++) {
     let article = jsonData[i];
-    $(blurbArts[i]).html(`<img class="vhp-art-${article.art}"/>`);
+    $(blurbArts[i]).html(`<div class="vhp-art-${article.art}"/>`);
     blurbs[i].innerHTML = `<h3>${article.title}</h3><p>${article.blurb}</p>`;
   }
 }
-

--- a/app/assets/stylesheets/common/art.scss
+++ b/app/assets/stylesheets/common/art.scss
@@ -1,9 +1,9 @@
-.vhp-art-broken        { content: image-url('art/broken.jpg') };
-.vhp-art-stones        { content: image-url('art/stones.jpg') };
-.vhp-art-eroded        { content: image-url('art/eroded.jpg') };
-.vhp-art-fuzz          { content: image-url('art/fuzz.jpg') };
-.vhp-art-lock-alike    { content: image-url('art/lock-alike.jpg') };
-.vhp-art-money         { content: image-url('art/money.jpg') };
-.vhp-art-rollercoaster { content: image-url('art/rollercoaster.jpg') };
-.vhp-art-snowflake     { content: image-url('art/snowflake.jpg') };
-.vhp-art-silent        { content: image-url('art/silent.jpg') };
+.vhp-art-broken        { content: image-url('art/broken.jpg'); width: 100%};
+.vhp-art-stones        { content: image-url('art/stones.jpg'); width: 100%};
+.vhp-art-eroded        { content: image-url('art/eroded.jpg'); width: 100%};
+.vhp-art-fuzz          { content: image-url('art/fuzz.jpg'); width: 100%};
+.vhp-art-lock-alike    { content: image-url('art/lock-alike.jpg'); width: 100%};
+.vhp-art-money         { content: image-url('art/money.jpg'); width: 100%};
+.vhp-art-rollercoaster { content: image-url('art/rollercoaster.jpg'); width: 100%};
+.vhp-art-snowflake     { content: image-url('art/snowflake.jpg'); width: 100%};
+.vhp-art-silent        { content: image-url('art/silent.jpg'); width: 100%};


### PR DESCRIPTION
This fix still works for Chrome and Firefox. It does not work for Edge at the moment. However, a new Chromium-based Edge is soon going to come out so we'll re-test compatibility at that point.

