### PR TITLE
performance: move markdown call to initial text loading (#627)

### DIFF
--- a/lib/event_generators/weekly_report_events.rb
+++ b/lib/event_generators/weekly_report_events.rb
@@ -7,11 +7,11 @@ class WeeklyReportEvents
   include ApplicationHelper
 
   def initialize
-    @report_desc = Writing.event_article('weekly-overall')
-    @newdev_desc = Writing.event_article('weekly-newdevs')
-    @revert_desc = Writing.event_article('weekly-reverts')
-    @owner_desc = Writing.event_article('weekly-ownership')
-    @refactors_desc = Writing.event_article('weekly-refactors')
+    @report_desc = markdown(Writing.event_article('weekly-overall'))
+    @newdev_desc = markdown(Writing.event_article('weekly-newdevs'))
+    @revert_desc = markdown(Writing.event_article('weekly-reverts'))
+    @owner_desc = markdown(Writing.event_article('weekly-ownership'))
+    @refactors_desc = markdown(Writing.event_article('weekly-refactors'))
   end
 
   def cve_from_filename(f)
@@ -24,7 +24,7 @@ class WeeklyReportEvents
     tags =   []
     vuln_events = []
     cooks_tag = add_cooks_tag
-    logger.info "Parsing JSON weeklies"
+    logger.info "Parsing & prepping weeklies"
     Dir["#{repo_path}/commits/weeklies/*.json"].each do |file|
       json = File.open(file) { |f| JSON.load(f) }
       v = Vulnerability.find_by(cve: cve_from_filename(file))
@@ -44,9 +44,9 @@ class WeeklyReportEvents
         tags << too_many_cooks(v, cooks_tag, num_devs) if num_devs >= 10
         v.notes['num_devs'] = num_devs
         v.save
-        vuln_events += new_events.compact.map do |e|
-          VulnerabilityEvent.new(event: e, vulnerability: v)
-        end
+        # vuln_events += new_events.compact.map do |e|
+        #   VulnerabilityEvent.new(event: e, vulnerability: v)
+        # end
         events += new_events.compact
       end
     end
@@ -74,7 +74,7 @@ class WeeklyReportEvents
       event_type: 'changes',
       title: "#{report['commits']} commits by #{num_devs} developers, " +
                       "#{churn} lines changed",
-      description: markdown(desc),
+      description: desc,
       date: report['date']
     )
   end
@@ -89,7 +89,7 @@ class WeeklyReportEvents
       date: report['date'],
       event_type: 'new developer',
       title: "#{num_new_devs} new developers",
-      description: markdown(desc)
+      description: desc
     )
   end
 
@@ -101,7 +101,7 @@ class WeeklyReportEvents
       date: report['date'],
       title: "Code ownership changed",
       event_type: 'owner change',
-      description: markdown(desc)
+      description: desc
     )
   end
 
@@ -114,7 +114,7 @@ class WeeklyReportEvents
       date: report['date'],
       title: "#{report['reverts']} revert commits",
       event_type: 'reverts',
-      description: markdown(desc)
+      description: desc
     )
   end
 
@@ -127,7 +127,7 @@ class WeeklyReportEvents
       date: report['date'],
       title: "#{report['refactor']} refactor commits",
       event_type: 'refactors',
-      description: markdown(desc)
+      description: desc
     )
   end
 

--- a/lib/event_generators/weekly_report_events.rb
+++ b/lib/event_generators/weekly_report_events.rb
@@ -44,9 +44,9 @@ class WeeklyReportEvents
         tags << too_many_cooks(v, cooks_tag, num_devs) if num_devs >= 10
         v.notes['num_devs'] = num_devs
         v.save
-        # vuln_events += new_events.compact.map do |e|
-        #   VulnerabilityEvent.new(event: e, vulnerability: v)
-        # end
+        vuln_events += new_events.compact.map do |e|
+          VulnerabilityEvent.new(event: e, vulnerability: v)
+        end
         events += new_events.compact
       end
     end

--- a/lib/loaders/vulnerability_loader.rb
+++ b/lib/loaders/vulnerability_loader.rb
@@ -8,6 +8,7 @@ class VulnerabilityLoader
     vulnerabilities = []
     fixes = []
     vccs = []
+    @log.info 'Parsing YMLs and making models'
     Dir["#{repo_path}/cves/*.yml"].each do |file|
       begin
         yml = File.open(file) { |f| YAML.load(f) }

--- a/lib/tasks/chromium.rake
+++ b/lib/tasks/chromium.rake
@@ -36,6 +36,8 @@ namespace :data do
       'data:chromium:load',
       'data:chromium:events',
       'data:chromium:tags',
+      'data:optimize',
+      'data:clear_cache',
     ]
 
     desc 'Check if Chromium data has been loaded'


### PR DESCRIPTION
This contributes to improving #627 - markdown() was being called WAAAY too much and was slowing us down. 

I moved the markdown() call to the initial load.

Here's my benchmarking:

**Old Way**
```
I, [2019-11-11T16:52:33.639138 #11548]  INFO -- data:chromium: Generating weekly report events and tags
I, [2019-11-11T16:52:33.660121 #11548]  INFO -- data:events:weeklies: Parsing JSON weeklies
I, [2019-11-11T16:56:38.437633 #11548]  INFO -- data:events:weeklies: Inserting event and tag data
```

...so about 4 minutes 35 seconds on `Parsing JSON weeklies` on my work desktop

**New Way**

```
I, [2019-11-11T17:07:33.569327 #19760]  INFO -- data:chromium: Generating weekly report events and tags
I, [2019-11-11T17:07:33.600576 #19760]  INFO -- data:events:weeklies: Parsing & prepping weeklies
I, [2019-11-11T17:08:08.199851 #19760]  INFO -- data:events:weeklies: Inserting event and tag data
```

...to about 35 seconds

WOO!! 

Note: I used the rbspy tool to find out that most of our time we were hanging out in the `kramdown` gem which gave me the clue that we were calling `markdown` too much.


