### PR TITLE
Fix syntax error to get icon color working (#630)

### DIFF
--- a/app/assets/javascripts/timeline/timelines.js
+++ b/app/assets/javascripts/timeline/timelines.js
@@ -510,7 +510,7 @@ function timelines(settings) {
                          .format('MMMM Do, YYYY');
       $('#legend-body').html(`
         <i class="material-icons legend-icon"
-           style="background-color: "${event.style_color}">
+           style="background-color: ${event.style_color}">
            ${event.style_icon}
         </i>
         <p class="legend-desc">${event.title}</p>


### PR DESCRIPTION
Somehow a double quote got in there and ruined the coloring of the icons.
#630 