### PR TITLE
Fix wrong spelling of icon (#575)

### DIFF
--- a/lib/event_generators/weekly_report_events.rb
+++ b/lib/event_generators/weekly_report_events.rb
@@ -166,7 +166,7 @@ class WeeklyReportEvents
   def revert_style
     @revert_style ||= Style.find_or_create_by!(
       name: 'revert_style',
-      icon: 'compare_arrow',
+      icon: 'compare_arrows',
       color: '#FF953D',
     )
   end


### PR DESCRIPTION
It was trying to use an icon named "compare" because it didn't recognize "compare_arrow". Somewhere along the way, it became elongated as well. Fixing the spelling issue fixed the elongation.
#575 