### PR TITLE
Load timeline.js properly for Firefox (#599)

### DIFF
--- a/app/views/vulnerabilities/show.html.erb
+++ b/app/views/vulnerabilities/show.html.erb
@@ -273,6 +273,5 @@ This DOM element is duplicated, populated, and then shown.
   var vulnerability_id = <%= @vulnerability.id %>
 </script>
 
-<%= javascript_include_tag "timeline", async: Rails.env.production? %>
-<%= javascript_include_tag "timeline/timelines", async: Rails.env.production? %>
-<%= javascript_include_tag "vulnerabilities/show", async: Rails.env.production? %>
+<%= javascript_include_tag "timeline/timelines" %>
+<%= javascript_include_tag "vulnerabilities/show" %>


### PR DESCRIPTION
Load JS properly without async and only once. This hopefully works on Firefox and Safari in production. Works locally, and there's no reason it should be different for production now since I took out the `production?` check.