### PR TITLE
Improve display of table on small devices (#529)

### DIFF
--- a/app/assets/javascripts/developers/show.js
+++ b/app/assets/javascripts/developers/show.js
@@ -122,38 +122,50 @@ $(document).ready( function() {
                 setPunchcardUp(jsonData);
             });
 
-            $('#datatable').dataTable({
-                destroy: true,
-                data: jsonData,
-                order: [[1, "asc"]],
-                language: languageInfo(),
-                rowCallback: function(row, data, index){
-                  $(row).on('click', function(){
-                    var url = "/commits/" + data.id;
-                    window.location.assign(url);
-                  })
-                },
-                initComplete: function () {
-                  $('#loading').remove();
-                  buildTopNav();
-                },
-                columns: [
-                  { title: 'Commit Hash', data: 'commit_hash', defaultContent: 'Null',
-                    render: function(data) {
-                      return data.substring(0, 10);
-                    }
-                  },
-                  { title: 'Date Created', data: 'date_created', defaultContent: 'Unknown',
-                    render: (data, type, row) => renderDateColumn(data, type, row, 'MMMM DD, YYYY, h:mm a', false)
-                  },
-                  { title: 'Lines Changed', data: 'notes.churn', defaultContent: 'Unknown' },
-                  { title: 'Abbreviated Commit Message', data: 'message', defaultContent: 'None',
-                    render: function(data) {
-                      return data.split('\n')[0];
-                    }
+            var table = $('#datatable').DataTable({
+              destroy: true,
+              data: jsonData,
+              order: [[1, "asc"]],
+              language: languageInfo(),
+              rowCallback: function(row, data, index){
+                $(row).on('click', function(){
+                  var url = "/commits/" + data.id;
+                  window.location.assign(url);
+                })
+              },
+              initComplete: function () {
+                $('#loading').remove();
+                buildTopNav();
+              },
+              columns: [
+                { title: 'Commit Hash', data: 'commit_hash', defaultContent: 'Null',
+                  render: function(data) {
+                    return data.substring(0, 10);
                   }
-                ]
+                },
+                { title: 'Date Created', data: 'date_created', defaultContent: 'Unknown',
+                  render: function(data, type, row) {
+                    let displayFormat = 'MMMM DD, YYYY, h:mm a';
+                    // If the screen is small, show a shortened date
+                    if ($(window).width() < 500) {
+                      displayFormat = 'MMMM DD, YYYY';
+                    }
+                    return renderDateColumn(data, type, row, displayFormat, false)
+                  }
+                },
+                { title: 'Lines Changed', data: 'notes.churn', defaultContent: 'Unknown' },
+                { title: 'Abbreviated Commit Message', data: 'message', name: 'commit_message', defaultContent: 'None',
+                  render: function(data) {
+                    return data.split('\n')[0];
+                  }
+                }
+              ]
             });
+
+            // The commit message clutters up the screen on mobile devices
+            if ($(window).width() < 500) {
+              table.columns('commit_message:name').visible(false);
+            }
         }
     });
 

--- a/app/assets/javascripts/developers/show.js
+++ b/app/assets/javascripts/developers/show.js
@@ -110,6 +110,10 @@ function setPunchcardUp(jsonData) {
   punch.plotActivities(frequencies);
 }
 
+function renderAsLink(data, row) {
+    return '<a class="dt_row" href="/commits/' + row.id + '">' + data + '</a>';
+}
+
 $(document).ready( function() {
     $.ajax({
         url: "/api/developers/" + $('#developer_id').text() + "/commits",
@@ -123,49 +127,38 @@ $(document).ready( function() {
             });
 
             var table = $('#datatable').DataTable({
+              responsive: true,
               destroy: true,
               data: jsonData,
               order: [[1, "asc"]],
               language: languageInfo(),
-              rowCallback: function(row, data, index){
-                $(row).on('click', function(){
-                  var url = "/commits/" + data.id;
-                  window.location.assign(url);
-                })
-              },
               initComplete: function () {
                 $('#loading').remove();
                 buildTopNav();
               },
               columns: [
                 { title: 'Commit Hash', data: 'commit_hash', defaultContent: 'Null',
-                  render: function(data) {
-                    return data.substring(0, 10);
+                  render: function(data, type, row) {
+                    return renderAsLink(data.substring(0, 10), row);
                   }
                 },
                 { title: 'Date Created', data: 'date_created', defaultContent: 'Unknown',
                   render: function(data, type, row) {
-                    let displayFormat = 'MMMM DD, YYYY, h:mm a';
-                    // If the screen is small, show a shortened date
-                    if ($(window).width() < 500) {
-                      displayFormat = 'MMMM DD, YYYY';
-                    }
-                    return renderDateColumn(data, type, row, displayFormat, false)
+                    return renderAsLink(renderDateColumn(data, type, row, 'MMMM DD, YYYY, h:mm a', false), row);
                   }
                 },
-                { title: 'Lines Changed', data: 'notes.churn', defaultContent: 'Unknown' },
+                { title: 'Lines Changed', data: 'notes.churn', defaultContent: 'Unknown',
+                  render: function(data, type, row) {
+                    return renderAsLink(data, row);
+                  }
+                },
                 { title: 'Abbreviated Commit Message', data: 'message', name: 'commit_message', defaultContent: 'None',
-                  render: function(data) {
-                    return data.split('\n')[0];
+                  render: function(data, type, row) {
+                    return renderAsLink(data.split('\n')[0], row);
                   }
                 }
               ]
             });
-
-            // The commit message clutters up the screen on mobile devices
-            if ($(window).width() < 500) {
-              table.columns('commit_message:name').visible(false);
-            }
         }
     });
 


### PR DESCRIPTION
I made the datatable responsive, like how it is on vulnerabilities#index. However, because a responsive datable adds a clickable plus button to a row when the screen size shrinks, I had to change how clicking is handled. Now, instead of the entire row being a link that'll take you to the commits page, each string of text is a link, and the plus button will expand to show you any hidden columns. Without this change, clicking the plus button would inadvertently take you to the commits page. (#529)

I also fixed some inconsistent spacing and tabbing.