### PR TITLE
Implement grow and clear buttons for timeline (#588)

### DIFF
--- a/app/assets/javascripts/timeline/timelines.js
+++ b/app/assets/javascripts/timeline/timelines.js
@@ -27,6 +27,7 @@ function timelines(settings) {
     this.minViewDate = this.absMinDate;
     this.maxViewDate = this.absMaxDate;
     this.xAxisHeight = settings.xAxisHeight;
+    this.topBarHeight = this.xAxisHeight / 2;
     this.overflowHeight = 20;
     this.fade_ms = settings.fade_ms;
     this.validTypes = [];
@@ -61,11 +62,14 @@ function timelines(settings) {
     };
 
     this.initYAxisScale = function() {
-        this.cLim = Math.floor(this.plotHeight / (this.chicHeight + 1));
+        this.chicLimit = Math.floor((this.plotHeight - this.topBarHeight) / (this.chicHeight + 1));
+
+        // Scales the y axis such that it'll make room for the top bar and
+        // any overflow icons above the chiclets
         this.y = d3.scaleLinear()
-                   .domain([0, this.cLim])
+                   .domain([0, this.chicLimit])
                    .range([this.plotHeight,
-                           this.overflowHeight - this.chicHeight]);
+                           this.overflowHeight - this.chicHeight + this.topBarHeight]);
     };
 
     this.initSVG = function() {
@@ -86,6 +90,12 @@ function timelines(settings) {
         this.plotHeight = this.svgHeight - this.xAxisHeight - this.overflowHeight - 2;
 
         this.initYAxisScale();
+
+        this.svg.append('g')
+          .attr('id', 'top-bar')
+          .append('rect')
+            .attr('width', '100%')
+            .attr('height', this.topBarHeight);
     };
 
     /**
@@ -455,8 +465,6 @@ function timelines(settings) {
         var cols = Object.keys(this.eDict);
         var tipId = 0;
         var tip;
-        var oIndex = 0;
-        var oCount = 0;
         var self = this;
         cols.forEach(function(key) {
             var eArr = self.eDict[key];
@@ -467,7 +475,7 @@ function timelines(settings) {
                 var event = eArr[i];
                 tip = self.renderToolTips(tip, tipId);
                 tipId += 1;
-                if (yIndex < self.cLim) {
+                if (yIndex < self.chicLimit) {
                     if (event.event_type == 'release') {
                         self.drawFlag(tip, new Date(key), releaseIndex, event);
                         releaseIndex++;
@@ -476,15 +484,11 @@ function timelines(settings) {
                         yIndex++;
                     }
                 } else {
-                    if (oCount === 0) {
-                        oIndex = yIndex;
-                    }
-                    oCount += 1;
                     colOverFArr.push(event);
                 }
             }
             if (colOverFArr.length > 0) {
-                self.drawOverflow(tip, new Date(key), oIndex, colOverFArr);
+                self.drawOverflow(tip, new Date(key), colOverFArr);
             }
         });
     };
@@ -623,23 +627,18 @@ function timelines(settings) {
 
     /**
     * Draws the reset button that resets the timeline to the default height
-    * when clicked.
     */
     this.drawResetButton = function() {
-      // If the reset button already exists, remove it before adding another one
-      d3.select('#reset-button').remove();
-
       let timelineHeight = $('#hTimeline').height();
       let timelineWidth = $('#hTimeline').width();
-      let buttonHeight = this.chicHeight * 2;
+      let buttonHeight = this.topBarHeight;
       let buttonWidth = this.chicWidth * 4;
-      let yTransform = Math.round(timelineHeight - this.xAxisHeight - buttonHeight - 4);
       let xTransform = timelineWidth - buttonWidth - (this.chicWidth / 2) - 2;
 
       let button = d3.select('#hTimeline')
         .append('g')
         .attr('id', 'reset-button')
-        .attr('transform', `translate(${xTransform}, ${yTransform})`);
+        .attr('transform', `translate(${xTransform}, 0)`);
 
       button.append('rect')
         .attr('height', buttonHeight)
@@ -659,47 +658,76 @@ function timelines(settings) {
       });
 
       button.on('mouseover', function() {
-        d3.select(this).select('rect').attr('style', 'fill: rgb(153, 51, 255)');
+        d3.select(this).select('rect').attr('style', 'fill: #9933ff');
       });
 
       button.on('mouseout', function() {
-        d3.select(this).select('rect').attr('style', 'fill: grey');
+        d3.select(this).select('rect').attr('style', 'fill: #bbbbbb');
       });
     }
 
-    this.drawOverflow = function(tip, col, yIndex, events) {
+    this.drawOverflow = function(tip, col, events) {
+        var cH2 = this.chicHeight / 2;
         var startX = this.x(col) + (this.chicWidth / 2);
-        var startY = 0;
+        var startY = this.topBarHeight + cH2; // leave room for the top bar
+        var vertLine = "M" + startX + " " + startY + " V " + (this.chicHeight + this.topBarHeight + cH2);
+        var horLine = "M" + (startX - cH2) + " " + (startY + cH2) + " H " + (startX + cH2);
         var self = this;
 
-        // TODO: do something about the hardcoded numbers
-        // TODO: provide text on hover over
-        var hoverOver = this.svg.append("text")
-          .attr('x', 100)
-          .attr('y', 100)
-          .style('visibility', 'hidden')
-          .text("Click here to see a few more events.");
-
         this.svg.append("path")
-          .attr("d", "M" + startX + " " + startY + " V " + this.chicHeight + "M" + (startX - (this.chicHeight / 2)) + " " + (startY + (this.chicHeight / 2)) + " H " + (startX + (this.chicHeight/2)) )
+          .attr("d", vertLine + horLine) // combines both lines to form a + symbol
           .attr("stroke-width", 3)
           .attr("stroke", "#808080")
           .attr('class', 'overflowIcon')
-          .on('click', function (d) {
+          .on('click', function(d) {
             self.showMoreEvents();
           })
-          .on('mouseenter', function () { // show chicklet
+          .on('mouseenter', function() { // show chiclet
             d3.select(this).attr("stroke", "#9933ff")
-              .attr("fill", function () {
+              .attr("fill", function() {
                 return "#9933ff";
               });
+
+            // Display an overview of the overflowed events
             self.showOverflowHover(events);
-            hoverOver.style('visibility', 'visible')
+
+            // Show tooltip
+            var tooltipY = startY + self.chicHeight + 10; // + 10 to account for cursor
+            var textXOffset = 5 // positions the text inside the rect horizontally
+            var gTextBox = self.svg.append("g")
+              .attr('id', 'overflow-tooltip');
+            var rectTextBox = gTextBox.append("rect")
+              .attr('rx', self.iconCornerRadius)
+              .attr('ry', self.iconCornerRadius)
+              .attr('x', startX)
+              .attr('y', tooltipY);
+            var textBox = gTextBox.append("text")
+              .attr('y', tooltipY + 18); // + 18 to position the text inside the rect
+            var topText = textBox.append("tspan")
+              .text("Click here to see a")
+              .attr('x', startX + textXOffset);
+            var bottomText = textBox.append("tspan")
+              .text("few more events.")
+              .attr('x', startX + textXOffset)
+              .attr('dy', 18);
+
+            // Resize the rect to be slightly larger than the text inside of it
+            var bBox = gTextBox.node().getBBox();
+            rectTextBox.attr('height', bBox.height + 10)
+              .attr('width', bBox.width + 10);
+
+            // Reposition the rect and text if they extend past the SVG
+            var tooltipOverflow = startX + bBox.width + 15 - self.svgWidth;
+            if (tooltipOverflow > 0) {
+              rectTextBox.attr('x', rectTextBox.attr('x') - tooltipOverflow);
+              topText.attr('x', topText.attr('x') - tooltipOverflow);
+              bottomText.attr('x', bottomText.attr('x') - tooltipOverflow);
+            }
           })
-          .on('mouseleave', function () { // hide tooltip
+          .on('mouseleave', function() { // hide tooltip
             d3.select(this).attr("stroke", "#808080");
             tip.transition().style("display", "none");
-            hoverOver.style('visibility', 'hidden')
+            self.svg.select("#overflow-tooltip").remove();
           });
     };
 

--- a/app/assets/javascripts/timeline/timelines.js
+++ b/app/assets/javascripts/timeline/timelines.js
@@ -625,7 +625,7 @@ function timelines(settings) {
     * Draws the reset button that resets the timeline to the default height
     * when clicked.
     */
-    this.drawResetButton = function () {
+    this.drawResetButton = function() {
       // If the reset button already exists, remove it before adding another one
       d3.select('#reset-button').remove();
 
@@ -645,14 +645,7 @@ function timelines(settings) {
         .attr('height', buttonHeight)
         .attr('width', buttonWidth)
         .attr('rx', this.iconCornerRadius)
-        .attr('ry', this.iconCornerRadius)
-        .attr('style', 'outline: thin solid blue');
-
-      // TODO: only extend the height to the top of the tallest column and
-      //       dynamically change height when zoom changes if the tallest column
-      //       is different
-      // TODO: the corner rounding isn't working
-      // TODO: do something about the hardcoded numbers
+        .attr('ry', this.iconCornerRadius);
 
       button.append('text')
         .text("Reset")
@@ -666,11 +659,11 @@ function timelines(settings) {
       });
 
       button.on('mouseover', function() {
-        d3.select(this).select('rect').attr('style', 'outline: thin solid lightblue');
+        d3.select(this).select('rect').attr('style', 'fill: rgb(153, 51, 255)');
       });
 
       button.on('mouseout', function() {
-        d3.select(this).select('rect').attr('style', 'outline: thin solid blue');
+        d3.select(this).select('rect').attr('style', 'fill: grey');
       });
     }
 
@@ -678,6 +671,15 @@ function timelines(settings) {
         var startX = this.x(col) + (this.chicWidth / 2);
         var startY = 0;
         var self = this;
+
+        // TODO: do something about the hardcoded numbers
+        // TODO: provide text on hover over
+        var hoverOver = this.svg.append("text")
+          .attr('x', 100)
+          .attr('y', 100)
+          .style('visibility', 'hidden')
+          .text("Click here to see a few more events.");
+
         this.svg.append("path")
           .attr("d", "M" + startX + " " + startY + " V " + this.chicHeight + "M" + (startX - (this.chicHeight / 2)) + " " + (startY + (this.chicHeight / 2)) + " H " + (startX + (this.chicHeight/2)) )
           .attr("stroke-width", 3)
@@ -686,16 +688,18 @@ function timelines(settings) {
           .on('click', function (d) {
             self.showMoreEvents();
           })
-          .on("mouseenter", function () { // show chicklet
+          .on('mouseenter', function () { // show chicklet
             d3.select(this).attr("stroke", "#9933ff")
               .attr("fill", function () {
                 return "#9933ff";
               });
             self.showOverflowHover(events);
+            hoverOver.style('visibility', 'visible')
           })
-          .on("mouseleave", function () { // hide tooltip
+          .on('mouseleave', function () { // hide tooltip
             d3.select(this).attr("stroke", "#808080");
             tip.transition().style("display", "none");
+            hoverOver.style('visibility', 'hidden')
           });
     };
 

--- a/app/assets/javascripts/timeline/timelines.js
+++ b/app/assets/javascripts/timeline/timelines.js
@@ -232,11 +232,15 @@ function timelines(settings) {
       this.drawXAxis(selectedZoom);
       this.plotEvents();
       this.updateVerticalTimeline();
+
+      if (this.additionalHeight != 0) {
+        this.drawResetButton();
+      }
     };
 
     this.sizeChanged = function() {
-      this.init();
       var selectedZoom = $('#zoom-dropdown').val();
+      this.init();
       this.updateToggledFilters();
       this.initEventDict(this.calculateDateRange(this.minViewDate, this.maxViewDate));
       this.populateEventDict();
@@ -606,9 +610,68 @@ function timelines(settings) {
             });
     };
 
+    /**
+     * Increases the height of the timeline to show more events. The height
+     * is increased 150% relative to the original height. Also adds a "reset"
+     * button to reset the height.
+     */
     this.showMoreEvents = function() {
       this.additionalHeight += this.timelineHeight / 2;
       this.sizeChanged();
+      this.drawResetButton();
+    }
+
+    /**
+    * Draws the reset button that resets the timeline to the default height
+    * when clicked.
+    */
+    this.drawResetButton = function () {
+      // If the reset button already exists, remove it before adding another one
+      d3.select('#reset-button').remove();
+
+      let timelineHeight = $('#hTimeline').height();
+      let timelineWidth = $('#hTimeline').width();
+      let buttonHeight = this.chicHeight * 2;
+      let buttonWidth = this.chicWidth * 4;
+      let yTransform = Math.round(timelineHeight - this.xAxisHeight - buttonHeight - 4);
+      let xTransform = timelineWidth - buttonWidth - (this.chicWidth / 2) - 2;
+
+      let button = d3.select('#hTimeline')
+        .append('g')
+        .attr('id', 'reset-button')
+        .attr('transform', `translate(${xTransform}, ${yTransform})`);
+
+      button.append('rect')
+        .attr('height', buttonHeight)
+        .attr('width', buttonWidth)
+        .attr('rx', this.iconCornerRadius)
+        .attr('ry', this.iconCornerRadius)
+        .attr('style', 'outline: thin solid blue');
+
+      // TODO: only extend the height to the top of the tallest column and
+      //       dynamically change height when zoom changes if the tallest column
+      //       is different
+      // TODO: the corner rounding isn't working
+      // TODO: do something about the hardcoded numbers
+
+      button.append('text')
+        .text("Reset")
+        .attr('x', 20)
+        .attr('y', buttonHeight * 0.75);
+
+      var self = this;
+      button.on('click', function() {
+        self.additionalHeight = 0;
+        self.sizeChanged();
+      });
+
+      button.on('mouseover', function() {
+        d3.select(this).select('rect').attr('style', 'outline: thin solid lightblue');
+      });
+
+      button.on('mouseout', function() {
+        d3.select(this).select('rect').attr('style', 'outline: thin solid blue');
+      });
     }
 
     this.drawOverflow = function(tip, col, yIndex, events) {

--- a/app/assets/javascripts/timeline/timelines.js
+++ b/app/assets/javascripts/timeline/timelines.js
@@ -3,6 +3,7 @@
  * some helper methods to display the vertical timeline
  *
  * @param events - collection of events from backend sorted chronologically
+ * @param timelineHeight - initial height of the timeline (in em)
  * @param chicHeight (int) - height of a chiclet
  * @param chicWidth (int) - width of a chiclet
  * @param defaultZoomValue (string) - zoom level that the timeline will default to
@@ -14,6 +15,8 @@
  * @constructor
  */
 function timelines(settings) {
+    this.timelineHeight = settings.timelineHeight;
+    this.additionalHeight = 0; // Any extra height added to the timeline (in em)
     this.chicHeight = settings.chicHeight;
     this.chicWidth = settings.chicWidth;
     this.iconCornerRadius = 4;
@@ -74,7 +77,7 @@ function timelines(settings) {
             // viewBox is not used either (unlike our other SVGs)
             // i.e. so our aspect ratio is not fixed at all
             .attr('width', '100%')
-            .attr('height', '16em');
+            .attr('height', this.timelineHeight + this.additionalHeight + 'em');
         this.svgWidth = parseInt(this.svg.style('width')); // compute px
         this.svgHeight = parseInt(this.svg.style('height')); // compute px
         this.initXAxisScale();
@@ -206,9 +209,6 @@ function timelines(settings) {
       d3.selectAll("path.overflowIcon").remove();
     };
 
-    this.moveViewRight = function () {
-    }
-
     this.filterToggled = function() {
       this.cacheToggledFilters();
       this.initEventDict(this.calculateDateRange(this.minViewDate, this.maxViewDate));
@@ -233,6 +233,21 @@ function timelines(settings) {
       this.plotEvents();
       this.updateVerticalTimeline();
     };
+
+    this.sizeChanged = function() {
+      this.init();
+      var selectedZoom = $('#zoom-dropdown').val();
+      this.updateToggledFilters();
+      this.initEventDict(this.calculateDateRange(this.minViewDate, this.maxViewDate));
+      this.populateEventDict();
+      this.generateFilters();
+      this.cacheToggledFilters();
+      this.clearEventDrawings();
+      this.initXAxisScale();
+      this.drawXAxis(selectedZoom);
+      this.plotEvents();
+      this.updateVerticalTimeline();
+    }
 
     /**
      * Draw the events on the timeline
@@ -591,31 +606,34 @@ function timelines(settings) {
             });
     };
 
+    this.showMoreEvents = function() {
+      this.additionalHeight += this.timelineHeight / 2;
+      this.sizeChanged();
+    }
+
     this.drawOverflow = function(tip, col, yIndex, events) {
         var startX = this.x(col) + (this.chicWidth / 2);
         var startY = 0;
         var self = this;
         this.svg.append("path")
-            .attr("d", "M" + startX + " " + startY + " V " + this.chicHeight + "M" + (startX - (this.chicHeight / 2)) + " " + (startY + (this.chicHeight / 2)) + " H " + (startX + (this.chicHeight/2)) )
-            .attr("stroke-width", 3)
-            .attr("stroke", "#808080")
-            .attr('class', 'overflowIcon')
-            .on('click', function () { // link to horizontal-timeline
-                window.location.href = '#' + events[0].id;
-                d3.select(this).attr("stroke", "#00FF00")
-            })
-            .on("mouseenter", function () { // show chicklet
-                d3.select(this).attr("stroke", "#9933ff")
-                    .attr("fill", function () {
-                        return "#9933ff"
-                    });
-                //self.showTooltip(tip, events[0]);
-                self.showOverflowHover(events);
-            })
-            .on("mouseleave", function () { // hide tooltip
-                d3.select(this).attr("stroke", "#808080")
-                tip.transition().style("display", "none");
-            });
+          .attr("d", "M" + startX + " " + startY + " V " + this.chicHeight + "M" + (startX - (this.chicHeight / 2)) + " " + (startY + (this.chicHeight / 2)) + " H " + (startX + (this.chicHeight/2)) )
+          .attr("stroke-width", 3)
+          .attr("stroke", "#808080")
+          .attr('class', 'overflowIcon')
+          .on('click', function (d) {
+            self.showMoreEvents();
+          })
+          .on("mouseenter", function () { // show chicklet
+            d3.select(this).attr("stroke", "#9933ff")
+              .attr("fill", function () {
+                return "#9933ff";
+              });
+            self.showOverflowHover(events);
+          })
+          .on("mouseleave", function () { // hide tooltip
+            d3.select(this).attr("stroke", "#808080");
+            tip.transition().style("display", "none");
+          });
     };
 
     /**

--- a/app/assets/javascripts/vulnerabilities/show.js
+++ b/app/assets/javascripts/vulnerabilities/show.js
@@ -3,6 +3,7 @@ function initHTimeline(defaultZoom = 'vcc_to_fix'){
 
   settings = {
     margin: { top: 10, bottom: 45, left: 60, right: 60},
+    timelineHeight: 16,
     chicHeight: 14,
     chicWidth: 20,
     cLowerLim: 13,

--- a/app/assets/stylesheets/timeline.scss
+++ b/app/assets/stylesheets/timeline.scss
@@ -26,6 +26,5 @@
 }
 
 #reset-button rect {
-  fill: lightblue;
-  opacity: 80%;
+  fill: grey;
 }

--- a/app/assets/stylesheets/timeline.scss
+++ b/app/assets/stylesheets/timeline.scss
@@ -1,3 +1,9 @@
+@import "_settings.scss";
+
+#top-bar rect {
+  fill: none;
+}
+
 #zoom-dropdown {
   position: relative;
   font-weight: bold;
@@ -26,5 +32,13 @@
 }
 
 #reset-button rect {
-  fill: grey;
+  fill: #bbbbbb;
+}
+
+#overflow-tooltip {
+  font-size: 0.8em;
+
+  rect {
+    fill: $light-gray;
+  }
 }

--- a/app/assets/stylesheets/timeline.scss
+++ b/app/assets/stylesheets/timeline.scss
@@ -1,4 +1,5 @@
 #zoom-dropdown {
+  position: relative;
   font-weight: bold;
   margin: 0;
   padding: 0;
@@ -19,6 +20,12 @@
   float: right;
 }
 
-#zoom-dropdown {
-  position: relative;
+#reset-button {
+  position: fixed;
+  cursor: pointer;
+}
+
+#reset-button rect {
+  fill: lightblue;
+  opacity: 80%;
 }


### PR DESCRIPTION
I added a top bar above the timeline which contains the reset button when the timeline has been vertically extended. There's also tooltips for the overflow buttons now, so that's cool. #588 