### PR TITLE
Fix format of file lists on vertical timeline (#641)

### DIFF
--- a/lib/event_generators/weekly_report_events.rb
+++ b/lib/event_generators/weekly_report_events.rb
@@ -63,13 +63,13 @@ class WeeklyReportEvents
     churn = report['insertions'].to_i + report['deletions'].to_i
     num_devs = report['developers'].size.to_s
     file_list = report['files'].map { |f| " * `#{f}`" }.join("\n")
-    desc = @report_desc.gsub(':num_devs:',num_devs)
+    desc = @report_desc.gsub(':num_devs:', num_devs)
                        .gsub(':nice_date:', nice_date(report))
                        .gsub(':commits:', report['commits'].to_s)
                        .gsub(':insertions:', report['insertions'].to_s)
                        .gsub(':deletions:', report['deletions'].to_s)
                        .gsub(':num_files:', report['files'].size.to_s)
-                       .gsub(':file_list:', file_list)
+                       .gsub(':file_list:', markdown(file_list))
     Event.new(
       style: overall_report_style,
       event_type: 'changes',


### PR DESCRIPTION
The `markdown` method is normally only called in the `initialize` method of weekly_report_events.rb, which is before the list of files is created. I simply added another call to the `markdown` method to check over the list of files. #641