### PR TITLE
Fix chiclets overlapping from rounding issues (#615)

### DIFF
--- a/app/assets/javascripts/timeline/timelines.js
+++ b/app/assets/javascripts/timeline/timelines.js
@@ -51,7 +51,7 @@ function timelines(settings) {
     };
 
     this.initXAxisScale = function() {
-        halfChicWidth = this.chicWidth / 2;
+        var halfChicWidth = this.chicWidth / 2;
         this.x = d3.scaleTime()
                    .domain([this.minViewDate, this.maxViewDate])
                    .range([halfChicWidth, this.svgWidth - halfChicWidth]);
@@ -263,12 +263,11 @@ function timelines(settings) {
     //  * Bucket value is an array (soon to be an array of events)
     // We don't populate the events here just yet - just initializing buckets
     this.initEventDict = function(range) {
-        this.eDict = {}; // reset from prior updates
-        var inc = range / this.numCols;
-        for (var i = 0; i < this.numCols; i++) {
-          this.eDict[this.addDays(this.minViewDate, i * inc)] = [];
-        }
-        this.eDict[this.maxViewDate] = [];
+      this.eDict = {}; // reset from prior updates
+      var inc = range / this.numCols;
+      for (var i = 0; i < this.numCols; i++) {
+        this.eDict[this.addDays(this.minViewDate, i * inc)] = [];
+      }
     };
 
     /**
@@ -391,7 +390,9 @@ function timelines(settings) {
      */
     this.addDays = function(date, days) {
         var result = new Date(date);
-        result.setDate(result.getDate() + days);
+        result.setDate(result.getDate() + Math.floor(days));
+        var minutes = (days % 1) * 1440; // Gets the decimal from days and converts it into minutes
+        result.setMinutes(result.getMinutes() + Math.floor(minutes));
         return result;
     };
 
@@ -411,15 +412,15 @@ function timelines(settings) {
      * Go through columns and pick which column the event goes into based on
      * closest date
      * @param date - a js date object
-     * @returns Date - the date closest to the date provided in the js object which
+     * @returns {Date} - the date closest to the date provided in the js object which
      * corresponds to the key in the eDict
      */
     this.getCol = function(date) {
         var cols = Object.keys(this.eDict);
         var c = new Date(cols[0]);
         if (date && cols) {
-            for (var i = 0; i < cols.length - 1; i++) {
-                if (this.calculateDateRange(new Date(cols[i]), date) < this.calculateDateRange(c, new Date(cols[i]))) {
+            for (var i = 1; i < cols.length; i++) {
+                if (this.calculateDateRange(new Date(cols[i]), date) < this.calculateDateRange(c, date)) {
                     c = new Date(cols[i]);
                 }
             }


### PR DESCRIPTION
To fix #615, we simply needed to account for the minutes when creating the interval for the horizontal timeline. Previously, an increment of some number of days would separate columns (e.g., 4.6 days). However, that decimal would create rounding issues which led to some of the columns appearing inconsistently spaced.

While I was verifying that my changes didn't ruin the ordering of the events in the timeline, I also encountered #679 and fixed it. That fix is also in this pull request.