### PR TITLE
Fix Python, JS, and Java icons (#592)

### DIFF
--- a/app/assets/stylesheets/common/icons.scss
+++ b/app/assets/stylesheets/common/icons.scss
@@ -14,6 +14,19 @@ $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
   font-weight: normal;
   font-style: normal;
 }
+@import '@fortawesome/fontawesome-free/scss/brands.scss';
+@font-face {
+  font-family: 'Font Awesome 5 Brands';
+  font-style: normal;
+  font-weight: 900;
+  font-display: $fa-font-display;
+  src: asset_url('#{$fa-font-path}/fa-brands-400.eot');
+  src: asset_url('#{$fa-font-path}/fa-brands-400.eot?#iefix') format('embedded-opentype'),
+  asset_url('#{$fa-font-path}/fa-brands-400.woff2') format('woff2'),
+  asset_url('#{$fa-font-path}/fa-brands-400.woff') format('woff'),
+  asset_url('#{$fa-font-path}/fa-brands-400.ttf') format('truetype'),
+  asset_url('#{$fa-font-path}/fa-brands-400.svg#fontawesome') format('svg');
+}
 @import '@fortawesome/fontawesome-free/scss/solid.scss';
 @font-face {
   font-family: 'Font Awesome 5 Free';
@@ -28,8 +41,9 @@ $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
   asset_url('#{$fa-font-path}/fa-solid-900.svg#fontawesome') format('svg');
 }
 .fa,
+.fab,
 .fas {
-  font-family: 'Font Awesome 5 Free';
+  font-family: 'Font Awesome 5 Free', 'Font Awesome 5 Brands';
   font-weight: 900;
 }
 
@@ -100,8 +114,8 @@ $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
 .vhp-icon-hourglass     { @extend .fas; @extend .fa-hourglass; }
 .vhp-icon-info          { @extend .fi-info; }
 .vhp-icon-internal      { @extend .fas; @extend .fa-compress-arrows-alt; }
-.vhp-icon-java          { @extend .fas; @extend .fa-java; }
-.vhp-icon-javascript    { @extend .fas; @extend .fa-js-square; }
+.vhp-icon-java          { @extend .fab; @extend .fa-java; }
+.vhp-icon-javascript    { @extend .fab; @extend .fa-js-square; }
 .vhp-icon-key           { @extend .fas; @extend .fa-key; }
 .vhp-icon-lemon         { @extend .fas; @extend .fa-lemon; }
 .vhp-icon-microchip     { @extend .fas; @extend .fa-microchip; }
@@ -110,7 +124,7 @@ $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
 .vhp-icon-notes         { @extend .fi-clipboard-notes; }
 .vhp-icon-origin        { @extend .fas; @extend .fa-infinity; }
 .vhp-icon-people        { @extend .fas; @extend .fa-users; }
-.vhp-icon-python        { @extend .fas; @extend .fa-python; }
+.vhp-icon-python        { @extend .fab; @extend .fa-python; }
 .vhp-icon-robot         { @extend .fas; @extend .fa-robot; }
 .vhp-icon-ruby          { @extend .fas; @extend .fa-gem; }
 .vhp-icon-running       { @extend .fas; @extend .fa-running; }


### PR DESCRIPTION
I found that the Python icons also didn't work correctly. The programming language fonts are a part of the Font Awesome Brands font family. Was there a reason we weren't including the Brands font family before?