### PR TITLE
Fix the commit link on vertical timeline (#678)

### DIFF
--- a/lib/writing.rb
+++ b/lib/writing.rb
@@ -1,5 +1,5 @@
 class Writing
-  
+
   def self.tag_article(slug, warn_missing = true)
     slug_file = "tmp/checkout/vhp-writing/tags/#{slug}.md"
     begin
@@ -25,7 +25,7 @@ class Writing
     new_str.gsub!(':title:',       model.title) if model.respond_to? :title
     new_str.gsub!(':description:', model.description) if model.respond_to? :description
     new_str.gsub!(':type:',        model.type) if model.respond_to? :type
-    new_str.gsub!(':commit_hash:', model.commit_hash) if model.respond_to? :commit_hash
+    new_str.gsub!(':commit_hash:', model.commit.commit_hash) if model.respond_to? :commit and model.commit.respond_to? :commit_hash
     new_str.gsub!(':date:',        model.date.rfc2822) if model.respond_to? :date
 
     new_str = new_str.split(/(:notes[~\w]*:)/).each do |note|


### PR DESCRIPTION
Fixes #678.
The previous line of code never got ran because `model.commit_hash` didn't exist.

Also, I made this PR to add the linking on VCCs: https://github.com/VulnerabilityHistoryProject/vhp-writing/pull/4