### PR TITLE
Fixed issue #665 by forcing long lines to wrap.

### DIFF
--- a/app/assets/stylesheets/common/vhp.scss
+++ b/app/assets/stylesheets/common/vhp.scss
@@ -429,6 +429,11 @@ li.tabs-title a {
 
 .curator-notes {
   font-size: 0.8em;
+
+  pre {
+    word-wrap: break-word;
+    white-space: pre-wrap;
+  }
 }
 
 .tabs-panel #curate{


### PR DESCRIPTION
Added some CSS to force any overflowing lines in the curator notes to wrap to a new line.

Fixes Issue #665 