### PR TITLE
Remove duplicate calls on timeline init

### DIFF
--- a/app/assets/javascripts/timeline/timelines.js
+++ b/app/assets/javascripts/timeline/timelines.js
@@ -247,15 +247,9 @@ function timelines(settings) {
 
       this.updateToggledFilters();
       this.initEventDict(this.calculateDateRange(this.minViewDate, this.maxViewDate));
-      this.populateEventDict();
-      this.generateFilters();
       this.cacheToggledFilters();
       this.initXAxisScale();
-      d3.select('#htimeline-xaxis').remove();
       this.drawXAxis();
-      this.plotEvents();
-      this.fadeInSVG();
-      this.updateVerticalTimeline();
     };
 
     // The Event Dictionary is a map of the events by their time column

--- a/app/assets/javascripts/timeline/timelines.js
+++ b/app/assets/javascripts/timeline/timelines.js
@@ -246,7 +246,6 @@ function timelines(settings) {
       this.zoomLevels = zoomLevels;
 
       this.updateToggledFilters();
-      this.initEventDict(this.calculateDateRange(this.minViewDate, this.maxViewDate));
       this.cacheToggledFilters();
       this.initXAxisScale();
       this.drawXAxis();


### PR DESCRIPTION
Removed some functions calls from the populateTimelines() function since many of these are simply called immediately after when zoomChanged() is binded and initialized.The only functions necessary are ones that set the d3 stage or initialize values that zoomChanged() does not create.

Fixed #612 