### PR TITLE
Make some event types inactive by default

### DIFF
--- a/app/assets/javascripts/timeline/timelines.js
+++ b/app/assets/javascripts/timeline/timelines.js
@@ -11,7 +11,6 @@
  *  of the horizontal timeline
  * @param minDate (Date) - absolute minimum date from all events
  * @param maxDate (Date) - absolute maximum date from all events
- * @param hiddenTypes (array) - data-toggles that have been unchecked
  * @constructor
  */
 function timelines(settings) {
@@ -36,7 +35,6 @@ function timelines(settings) {
     this.svg;
     this.x;
     this.y;
-    this.hiddenTypes = settings.hiddenTypes;
     this.defaultZoomValue = settings.defaultZoomValue;
     this.zoomLevels; // Map of <display name, value> of every zoom level
 
@@ -209,9 +207,20 @@ function timelines(settings) {
       this.activeToggles = Array
         .from(document.querySelectorAll('input.htimeline_toggle:checked'))
         .map(i => i.dataset.name);
+
+      var tempInactiveToggles = this.inactiveToggles;
       this.inactiveToggles = Array
         .from(document.querySelectorAll('input.htimeline_toggle:not(:checked)'))
         .map(i => i.dataset.name);
+
+      // It's possible for a toggle to be inactive AND not currently rendered on
+      // the page. Therefore, we want to preserve all inactive toggles.
+      var self = this;
+      tempInactiveToggles.forEach(function (toggle) {
+        if (!self.activeToggles.includes(toggle)) {
+          self.inactiveToggles.push(toggle);
+        }
+      });
     };
 
     this.clearEventDrawings = function() {
@@ -273,6 +282,15 @@ function timelines(settings) {
       this.minViewDate = this.minEventDate;
       this.maxViewDate = this.maxEventDate;
       this.zoomLevels = zoomLevels;
+
+      // If there are event types that should be inactive by default, go
+      // ahead and add them to inactiveToggles
+      var self = this;
+      this.events.forEach(function(e) {
+        if (e.start_hidden == true && !self.inactiveToggles.includes(e.event_type)) {
+          self.inactiveToggles.push(e.event_type);
+        }
+      });
 
       this.updateToggledFilters();
       this.initEventDict(this.calculateDateRange(this.minViewDate, this.maxViewDate));
@@ -354,10 +372,8 @@ function timelines(settings) {
         var self = this; // 'this' will change when we enter forEach
         this.events.forEach(function(e) {
             if (self.shouldDrawEvent(e)) {
-                if (!self.hiddenTypes.includes(e.event_type)) {
-                    var col = self.getCol(e.date);
-                    self.eDict[col].push(e);
-                }
+                var col = self.getCol(e.date);
+                self.eDict[col].push(e);
             }
         });
     };

--- a/app/assets/javascripts/vulnerabilities/show.js
+++ b/app/assets/javascripts/vulnerabilities/show.js
@@ -8,7 +8,6 @@ function initHTimeline(defaultZoom = 'vcc_to_fix'){
     chicWidth: 20,
     cLowerLim: 13,
     cUpperLim: 15,
-    hiddenTypes: [],
     xAxisHeight: 43,
     fade_ms: 700,
     defaultZoomValue: defaultZoom,

--- a/app/controllers/vulnerabilities_controller.rb
+++ b/app/controllers/vulnerabilities_controller.rb
@@ -29,6 +29,7 @@ class VulnerabilitiesController < ApplicationController
         event_type: e.event_type,
         style_color: e.style.color,
         style_icon: e.style.icon,
+        start_hidden: e.start_hidden,
       }
     end
     render_json_for_api events

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,11 +89,12 @@ ActiveRecord::Schema.define(version: 20180514175418) do
   add_index :developers, :nickname, unique: false
 
   create_table "events", force: :cascade do |t|
-    t.string   "title",       null: false, default: 'Event'
-    t.string   "description", null: false, default: ''
-    t.string   "event_type",  null: false, default: ''
-    t.string   "date",        null: false, default: ':date:'
-    t.integer  "style_id",    null: false
+    t.string   "title",        null: false, default: 'Event'
+    t.string   "description",  null: false, default: ''
+    t.string   "event_type",   null: false, default: ''
+    t.string   "date",         null: false, default: ':date:'
+    t.integer  "style_id",     null: false
+    t.boolean  "start_hidden", null: false, default: false
   end
 
   add_index :events, :id,   unique: true

--- a/lib/event_generators/bounty_events.rb
+++ b/lib/event_generators/bounty_events.rb
@@ -17,7 +17,8 @@ class BountyEvents
             title: "Bounty awarded for #{vuln.cve}",
             event_type: 'bounty',
             date: vuln.notes['bounty']['date'],
-            description: markdown(Writing.embed_details(@desc, vuln))
+            description: markdown(Writing.embed_details(@desc, vuln)),
+            start_hidden: false
           )
           vuln.events << e
           vuln.save

--- a/lib/event_generators/fix_events.rb
+++ b/lib/event_generators/fix_events.rb
@@ -19,7 +19,8 @@ class FixEvents
         title: "Fix for #{fix.vulnerability.cve}: #{fix.commit.title}",
         date: fix.commit.date,
         event_type: 'fix',
-        description: markdown(Writing.embed_details(@desc, fix))
+        description: markdown(Writing.embed_details(@desc, fix)),
+        start_hidden: false
       )
       events << e
       vuln_events << VulnerabilityEvent.new(

--- a/lib/event_generators/release_events.rb
+++ b/lib/event_generators/release_events.rb
@@ -20,7 +20,8 @@ class ReleaseEvents
         title: ':title:',
         event_type: 'release',
         date: release.date_released,
-        description: Writing.event_article('release')
+        description: Writing.event_article('release'),
+        start_hidden: false
       )
     end
     return events

--- a/lib/event_generators/similar_events.rb
+++ b/lib/event_generators/similar_events.rb
@@ -50,7 +50,8 @@ class SimilarEvents
 
           See other cases of [:tags: #{vuln['cwe']}](/tags/#{vuln['tag_shortname']}).
         EOSTR
-        )
+        ),
+        start_hidden: false
       )
       events << e
       vuln_events << VulnerabilityEvent.new(vulnerability_id: vuln['vuln1_id'], event: e)

--- a/lib/event_generators/vcc_events.rb
+++ b/lib/event_generators/vcc_events.rb
@@ -19,7 +19,8 @@ class VccEvents
         title: "Vulnerability-contributing commit for #{vcc.vulnerability.cve}: #{vcc.commit.title}",
         date: vcc.commit.date,
         event_type: 'vcc',
-        description: markdown(Writing.embed_details(@desc, vcc))
+        description: markdown(Writing.embed_details(@desc, vcc)),
+        start_hidden: false
       )
       events << e
       vuln_events << VulnerabilityEvent.new(

--- a/lib/event_generators/vulnerability_events.rb
+++ b/lib/event_generators/vulnerability_events.rb
@@ -14,7 +14,8 @@ class VulnerabilityEvents
           date: v.announced,
           event_type: 'announced',
           title: "Vulnerability Announced for #{v.cve}",
-          description: markdown("The vulnerability was officially announced by the development team.")
+          description: markdown("The vulnerability was officially announced by the development team."),
+          start_hidden: false
         )
         v.events << e
         v.save

--- a/lib/event_generators/weekly_report_events.rb
+++ b/lib/event_generators/weekly_report_events.rb
@@ -72,11 +72,12 @@ class WeeklyReportEvents
                        .gsub(':file_list:', markdown(file_list))
     Event.new(
       style: overall_report_style,
+      date: report['date'],
       event_type: 'changes',
       title: "#{report['commits']} commits by #{num_devs} developers, " +
                       "#{churn} lines changed",
       description: desc,
-      date: report['date']
+      start_hidden: true
     )
   end
 
@@ -90,7 +91,8 @@ class WeeklyReportEvents
       date: report['date'],
       event_type: 'new developer',
       title: "#{num_new_devs} new developers",
-      description: desc
+      description: desc,
+      start_hidden: true
     )
   end
 
@@ -102,7 +104,8 @@ class WeeklyReportEvents
       date: report['date'],
       title: "Code ownership changed",
       event_type: 'owner change',
-      description: desc
+      description: desc,
+      start_hidden: false
     )
   end
 
@@ -115,7 +118,8 @@ class WeeklyReportEvents
       date: report['date'],
       title: "#{report['reverts']} revert commits",
       event_type: 'reverts',
-      description: desc
+      description: desc,
+      start_hidden: false
     )
   end
 
@@ -128,7 +132,8 @@ class WeeklyReportEvents
       date: report['date'],
       title: "#{report['refactor']} refactor commits",
       event_type: 'refactors',
-      description: desc
+      description: desc,
+      start_hidden: false
     )
   end
 


### PR DESCRIPTION
Fixes #574 by making the 'new developers' and 'changes' events disabled by default.