### PR TITLE
Fix vertical timeline event sorting in FF (#637)

### DIFF
--- a/app/assets/javascripts/vulnerabilities/show.js
+++ b/app/assets/javascripts/vulnerabilities/show.js
@@ -25,16 +25,13 @@ function initHTimeline(defaultZoom = 'vcc_to_fix'){
  */
 function sortEvents(events) {
     events.sort(function(a, b) {
-        var a = new Date(a.date);
-        var b = new Date(b.date);
-        return b.getTime() - a.getTime();
+        return b.date.getTime() - a.date.getTime();
     });
     return events;
 }
 
 function populateHTimeline(hTimeline, vulnEvents) {
   if(vulnEvents.length == 0) { return; }
-  vulnEvents = sortEvents(vulnEvents);
 
   var zoomLevels = new Map();
   zoomLevels.set('VCC to Fix', 'vcc_to_fix');
@@ -95,7 +92,6 @@ function populateHTimeline(hTimeline, vulnEvents) {
 }
 
 function populateVTimeline(vulnEvents) {
-  vulnEvents = sortEvents(vulnEvents);
   for (let e of vulnEvents) {
     block = $('#vtimeline-template').clone();
     block.attr('id', 'event_block_' + e.id);
@@ -150,17 +146,19 @@ $(document).ready( function() {
   $.ajax({
     url: `/api/vulnerabilities/${vulnerability_id}/events`,
     dataType: 'json',
-  }).done(function(vulnEvents){
-    $('#vtimeline_loading').remove();
-    populateVTimeline(vulnEvents);
-  }).done(function(vuln_events) {
-    for(let e of vuln_events) {
+  }).done(function(vulnEvents) {
+    for(let e of vulnEvents) {
       // Here we convert Rails AR date string to JS date object
       // using moment.js - different browsers treat time parsing differently
       // so we need to specify the date format string.
       e.date = new Date(moment(e.date,'YYYY-MM-DD hh:mm:ss Z'));
       events.push(e); //set to global events
     }
+
+    events = sortEvents(events);
+    $('#vtimeline_loading').remove();
+    populateVTimeline(events);
+
     $('#htimeline-loading').hide();
     populateHTimeline(hTimeline, events);
   });
@@ -174,5 +172,4 @@ $(document).ready( function() {
     $('#htimeline-loading').hide();
     populateHTimeline(hTimeline, events);
   }
-
 });


### PR DESCRIPTION
Fixes #637 by converting the datetime properly and simplifies the code a little bit.