### PR TITLE
Remove dataTable navigation buttons when one page exists

### DIFF
--- a/app/assets/javascripts/commits/index.js
+++ b/app/assets/javascripts/commits/index.js
@@ -17,6 +17,14 @@ $( document ).ready( function() {
                     window.location.assign(url);
                   })
                 },
+                preDrawCallback: function (settings) {
+                    // Removes "Previous" and "Next" buttons if there's only one page
+                    var api = new $.fn.dataTable.Api(settings);
+                    var pagination = $(this)
+                        .closest('.dataTables_wrapper')
+                        .find('.dataTables_paginate');
+                    pagination.toggle(api.page.info().pages > 1);
+                },
                 columnDefs: [
                   { "width": "10%", "targets": 0 }
                 ],

--- a/app/assets/javascripts/commits/index.js
+++ b/app/assets/javascripts/commits/index.js
@@ -17,14 +17,7 @@ $( document ).ready( function() {
                     window.location.assign(url);
                   })
                 },
-                preDrawCallback: function (settings) {
-                    // Removes "Previous" and "Next" buttons if there's only one page
-                    var api = new $.fn.dataTable.Api(settings);
-                    var pagination = $(this)
-                        .closest('.dataTables_wrapper')
-                        .find('.dataTables_paginate');
-                    pagination.toggle(api.page.info().pages > 1);
-                },
+                preDrawCallback: (settings) => hideSinglePagePagination(settings),
                 columnDefs: [
                   { "width": "10%", "targets": 0 }
                 ],

--- a/app/assets/javascripts/developers/index.js
+++ b/app/assets/javascripts/developers/index.js
@@ -42,6 +42,14 @@ $( document ).ready( function() {
                     window.location.assign(url);
                   })
                 },
+                preDrawCallback: function (settings) {
+                  // Removes "Previous" and "Next" buttons if there's only one page
+                  var api = new $.fn.dataTable.Api(settings);
+                  var pagination = $(this)
+                    .closest('.dataTables_wrapper')
+                    .find('.dataTables_paginate');
+                  pagination.toggle(api.page.info().pages > 1);
+                },
                 columnDefs: [
                   { "width": "10%", "targets": 0 }
                 ],

--- a/app/assets/javascripts/developers/index.js
+++ b/app/assets/javascripts/developers/index.js
@@ -42,14 +42,7 @@ $( document ).ready( function() {
                     window.location.assign(url);
                   })
                 },
-                preDrawCallback: function (settings) {
-                  // Removes "Previous" and "Next" buttons if there's only one page
-                  var api = new $.fn.dataTable.Api(settings);
-                  var pagination = $(this)
-                    .closest('.dataTables_wrapper')
-                    .find('.dataTables_paginate');
-                  pagination.toggle(api.page.info().pages > 1);
-                },
+                preDrawCallback: (settings) => hideSinglePagePagination(settings),
                 columnDefs: [
                   { "width": "10%", "targets": 0 }
                 ],

--- a/app/assets/javascripts/developers/show.js
+++ b/app/assets/javascripts/developers/show.js
@@ -136,14 +136,7 @@ $(document).ready( function() {
                 $('#loading').remove();
                 buildTopNav();
               },
-              preDrawCallback: function (settings) {
-                // Removes "Previous" and "Next" buttons if there's only one page
-                var api = new $.fn.dataTable.Api(settings);
-                var pagination = $(this)
-                  .closest('.dataTables_wrapper')
-                  .find('.dataTables_paginate');
-                pagination.toggle(api.page.info().pages > 1);
-              },
+              preDrawCallback: (settings) => hideSinglePagePagination(settings),
               columns: [
                 { title: 'Commit Hash', data: 'commit_hash', defaultContent: 'Null',
                   render: function(data, type, row) {

--- a/app/assets/javascripts/developers/show.js
+++ b/app/assets/javascripts/developers/show.js
@@ -136,6 +136,14 @@ $(document).ready( function() {
                 $('#loading').remove();
                 buildTopNav();
               },
+              preDrawCallback: function (settings) {
+                // Removes "Previous" and "Next" buttons if there's only one page
+                var api = new $.fn.dataTable.Api(settings);
+                var pagination = $(this)
+                  .closest('.dataTables_wrapper')
+                  .find('.dataTables_paginate');
+                pagination.toggle(api.page.info().pages > 1);
+              },
               columns: [
                 { title: 'Commit Hash', data: 'commit_hash', defaultContent: 'Null',
                   render: function(data, type, row) {

--- a/app/assets/javascripts/filepaths/offender_table.js
+++ b/app/assets/javascripts/filepaths/offender_table.js
@@ -49,6 +49,14 @@ function OffenderTable(offenders){
             autoWidth: false,
             data: filtered,
             order: [[2, "desc"]], /* Default sort */
+            preDrawCallback: function (settings) {
+                // Removes "Previous" and "Next" buttons if there's only one page
+                var api = new $.fn.dataTable.Api(settings);
+                var pagination = $(this)
+                    .closest('.dataTables_wrapper')
+                    .find('.dataTables_paginate');
+                pagination.toggle(api.page.info().pages > 1);
+            },
             columns:  [
                 {
                     title: 'Project',
@@ -123,4 +131,3 @@ function OffenderTable(offenders){
     }
 
 }
-

--- a/app/assets/javascripts/filepaths/offender_table.js
+++ b/app/assets/javascripts/filepaths/offender_table.js
@@ -49,14 +49,7 @@ function OffenderTable(offenders){
             autoWidth: false,
             data: filtered,
             order: [[2, "desc"]], /* Default sort */
-            preDrawCallback: function (settings) {
-                // Removes "Previous" and "Next" buttons if there's only one page
-                var api = new $.fn.dataTable.Api(settings);
-                var pagination = $(this)
-                    .closest('.dataTables_wrapper')
-                    .find('.dataTables_paginate');
-                pagination.toggle(api.page.info().pages > 1);
-            },
+            preDrawCallback: (settings) => hideSinglePagePagination(settings),
             columns:  [
                 {
                     title: 'Project',

--- a/app/assets/javascripts/global/commitsTable.js
+++ b/app/assets/javascripts/global/commitsTable.js
@@ -65,6 +65,14 @@ function editsTable(jsonData, tableName = '#edit_table') {
             }
             ],
         language: commitsLanguageInfo(),
+        preDrawCallback: function (settings) {
+            // Removes "Previous" and "Next" buttons if there's only one page
+            var api = new $.fn.dataTable.Api(settings);
+            var pagination = $(this)
+                .closest('.dataTables_wrapper')
+                .find('.dataTables_paginate');
+            pagination.toggle(api.page.info().pages > 1);
+        },
         initComplete: function () {
             $('#loading').remove();
             buildTopNav();

--- a/app/assets/javascripts/global/commitsTable.js
+++ b/app/assets/javascripts/global/commitsTable.js
@@ -65,14 +65,7 @@ function editsTable(jsonData, tableName = '#edit_table') {
             }
             ],
         language: commitsLanguageInfo(),
-        preDrawCallback: function (settings) {
-            // Removes "Previous" and "Next" buttons if there's only one page
-            var api = new $.fn.dataTable.Api(settings);
-            var pagination = $(this)
-                .closest('.dataTables_wrapper')
-                .find('.dataTables_paginate');
-            pagination.toggle(api.page.info().pages > 1);
-        },
+        preDrawCallback: (settings) => hideSinglePagePagination(settings),
         initComplete: function () {
             $('#loading').remove();
             buildTopNav();

--- a/app/assets/javascripts/global/datatables.js
+++ b/app/assets/javascripts/global/datatables.js
@@ -1,0 +1,6 @@
+function hideSinglePagePagination (settings) {
+  // Removes "Previous" and "Next" buttons if there's only one page
+  var api = new $.fn.dataTable.Api(settings);
+  var pagination = $('.dataTables_paginate');
+  pagination.toggle(api.page.info().pages > 1);
+}

--- a/app/assets/javascripts/global/vulnerabilitiesTable.js
+++ b/app/assets/javascripts/global/vulnerabilitiesTable.js
@@ -117,14 +117,7 @@ function vulnTable(jsonData, tableName = '#datatable'){
       ],
       columns: columnsInfo(),
       language: languageInfo(),
-      preDrawCallback: function (settings) {
-          // Removes "Previous" and "Next" buttons if there's only one page
-          var api = new $.fn.dataTable.Api(settings);
-          var pagination = $(this)
-              .closest('.dataTables_wrapper')
-              .find('.dataTables_paginate');
-          pagination.toggle(api.page.info().pages > 1);
-      },
+      preDrawCallback: (settings) => hideSinglePagePagination(settings),
       initComplete: function () {
           $('#loading').remove();
           buildTopNav();

--- a/app/assets/javascripts/global/vulnerabilitiesTable.js
+++ b/app/assets/javascripts/global/vulnerabilitiesTable.js
@@ -117,6 +117,14 @@ function vulnTable(jsonData, tableName = '#datatable'){
       ],
       columns: columnsInfo(),
       language: languageInfo(),
+      preDrawCallback: function (settings) {
+          // Removes "Previous" and "Next" buttons if there's only one page
+          var api = new $.fn.dataTable.Api(settings);
+          var pagination = $(this)
+              .closest('.dataTables_wrapper')
+              .find('.dataTables_paginate');
+          pagination.toggle(api.page.info().pages > 1);
+      },
       initComplete: function () {
           $('#loading').remove();
           buildTopNav();

--- a/app/assets/javascripts/tags/index.js
+++ b/app/assets/javascripts/tags/index.js
@@ -49,14 +49,7 @@ $( document ).ready( function() {
                 destroy: true,
                 data: jsonData,
                 pageLength: 50,
-                preDrawCallback: function (settings) {
-                    // Removes "Previous" and "Next" buttons if there's only one page
-                    var api = new $.fn.dataTable.Api(settings);
-                    var pagination = $(this)
-                        .closest('.dataTables_wrapper')
-                        .find('.dataTables_paginate');
-                    pagination.toggle(api.page.info().pages > 1);
-                },
+                preDrawCallback: (settings) => hideSinglePagePagination(settings),
                 columns: [
                     {
                         title: '<i class="vhp-icon-tags"></i> Tag',

--- a/app/assets/javascripts/tags/index.js
+++ b/app/assets/javascripts/tags/index.js
@@ -49,6 +49,14 @@ $( document ).ready( function() {
                 destroy: true,
                 data: jsonData,
                 pageLength: 50,
+                preDrawCallback: function (settings) {
+                    // Removes "Previous" and "Next" buttons if there's only one page
+                    var api = new $.fn.dataTable.Api(settings);
+                    var pagination = $(this)
+                        .closest('.dataTables_wrapper')
+                        .find('.dataTables_paginate');
+                    pagination.toggle(api.page.info().pages > 1);
+                },
                 columns: [
                     {
                         title: '<i class="vhp-icon-tags"></i> Tag',
@@ -72,7 +80,7 @@ $( document ).ready( function() {
                 initComplete: function () {
                     $('#loading').remove();
                     buildTopNav();
-                  }
+                }
             });
         }
     });

--- a/app/assets/javascripts/tags/show.js
+++ b/app/assets/javascripts/tags/show.js
@@ -61,6 +61,14 @@ $( document ).ready( function() {
           { "width": "40%", "targets": 1 }
           // { "width": "20%", "targets": 1 }
         ],
+        preDrawCallback: function (settings) {
+          // Removes "Previous" and "Next" buttons if there's only one page
+          var api = new $.fn.dataTable.Api(settings);
+          var pagination = $(this)
+            .closest('.dataTables_wrapper')
+            .find('.dataTables_paginate');
+          pagination.toggle(api.page.info().pages > 1);
+        },
         initComplete: function () {
           $('#loading').remove();
         }

--- a/app/assets/javascripts/tags/show.js
+++ b/app/assets/javascripts/tags/show.js
@@ -59,16 +59,8 @@ $( document ).ready( function() {
         columnDefs: [
           { "width": "16%", "targets": 0 },
           { "width": "40%", "targets": 1 }
-          // { "width": "20%", "targets": 1 }
         ],
-        preDrawCallback: function (settings) {
-          // Removes "Previous" and "Next" buttons if there's only one page
-          var api = new $.fn.dataTable.Api(settings);
-          var pagination = $(this)
-            .closest('.dataTables_wrapper')
-            .find('.dataTables_paginate');
-          pagination.toggle(api.page.info().pages > 1);
-        },
+        preDrawCallback: (settings) => hideSinglePagePagination(settings),
         initComplete: function () {
           $('#loading').remove();
         }


### PR DESCRIPTION
Fixes #644 by adding some custom code to each instance of `dataTable` or `DataTable` in our website. It's too bad we don't have one central place where the basic dataTable is defined.