### PR TITLE
Issue 854 - Datetime Fix

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 2020_10_20) do
     t.string   "title",             null: false, default: 'Event'
     t.string   "description",       null: false, default: ''
     t.string   "event_type",        null: false, default: ''
-    t.string   "date",              null: false
+    t.datetime "date",              null: false
     t.string   "color",             null: false, default: '#ccc'
     t.string   "icon",              null: false, default: 'info'
     t.boolean  "start_hidden",      null: false, default: false

--- a/lib/event_generators/bounty_events.rb
+++ b/lib/event_generators/bounty_events.rb
@@ -15,7 +15,7 @@ class BountyEvents
           Event.create!(
             title: "Bounty awarded for #{vuln.cve}",
             event_type: 'bounty',
-            date: vuln.notes['bounty']['date'],
+            date: Date.parse(vuln.notes['bounty']['date'].to_s),
             description: Writing.embed_details(@desc, vuln),
             icon: 'monetization_on',
             color: '#25C322',

--- a/lib/loaders/vulnerability_loader.rb
+++ b/lib/loaders/vulnerability_loader.rb
@@ -28,6 +28,9 @@ class VulnerabilityLoader
       begin
         start = Time.now
         yml = load_yml_the_vhp_way(file)
+        # if yml[:CVE] == "CVE-2012-2871"
+        #   puts yml
+        # end
         v   = create_vulnerability(yml, project)
         unless v.nil?
           fixes += create_fixes(v, yml)

--- a/lib/loaders/vulnerability_loader.rb
+++ b/lib/loaders/vulnerability_loader.rb
@@ -28,9 +28,6 @@ class VulnerabilityLoader
       begin
         start = Time.now
         yml = load_yml_the_vhp_way(file)
-        # if yml[:CVE] == "CVE-2012-2871"
-        #   puts yml
-        # end
         v   = create_vulnerability(yml, project)
         unless v.nil?
           fixes += create_fixes(v, yml)


### PR DESCRIPTION
Fixes #854  - events weren't showing up correctly on vulnerability timelines in Firefox and Safari due to datetime values not being stored correctly in the database.