### PR TITLE
Updated html to not display IE error for FireFox

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -93,7 +93,10 @@
       https://stackoverflow.com/a/21712356/16179502
       -->
       <script>
-        if (window.document.documentMode){ // internet explorer
+        var ua = window.navigator.userAgent;
+        var isIE = /MSIE|Trident/.test(ua);
+
+        if (isIE) {
             document.getElementById("ie-alert").style.display = "block";
         }
       </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -90,12 +90,11 @@
 
     <div class="alert-error" id="ie-alert" style="display:none">
       <!--
-      https://www.geeksforgeeks.org/how-to-detect-the-user-browser-safari-chrome-ie-firefox-and-opera-using-javascript/#:~:text=The%20browser%20on%20which%20the,string%20sent%20by%20the%20browser.
+      https://stackoverflow.com/a/21712356/16179502
       -->
       <script>
-        let userAgentString = navigator.userAgent;
-        if(userAgentString.indexOf("MSIE") > -1 ||  userAgentString.indexOf("rv:") > -1) {
-          document.getElementById("ie-alert").style.display = "block";
+        if (window.document.documentMode){ // internet explorer
+            document.getElementById("ie-alert").style.display = "block";
         }
       </script>
       Warning: Our website does not support Internet Explorer, please use Edge instead.


### PR DESCRIPTION
#886 

I downloaded Firefox and ensured that the error for a mistaken IE warning no longer occurs. However, since I am on a Mac and have no access to a Windows computer with the proper environment I do not have the ability to test if the IE warning still shows up for IE browsers.