### PR TITLE
Fix/issue 887

### DIFF
--- a/lib/writing.rb
+++ b/lib/writing.rb
@@ -23,11 +23,11 @@ class Writing
   def self.embed_details(str, model)
     new_str = str.strip
 
-    new_str.gsub(':title:',       model.title) if model.respond_to? :title
-    new_str.gsub(':description:', model.description) if model.respond_to? :description
-    new_str.gsub(':type:',        model.type) if model.respond_to? :type
-    new_str.gsub(':commit_hash:', model.commit.commit_hash) if model.respond_to? :commit and model.commit.respond_to? :commit_hash
-    new_str.gsub(':date:',        model.date.rfc2822) if model.respond_to? :date
+    new_str.gsub!(':title:',       model.title) if model.respond_to? :title
+    new_str.gsub!(':description:', model.description) if model.respond_to? :description
+    new_str.gsub!(':type:',        model.type) if model.respond_to? :type
+    new_str.gsub!(':commit_hash:', model.commit.commit_hash) if model.respond_to? :commit and model.commit.respond_to? :commit_hash
+    new_str.gsub!(':date:',        model.date.rfc2822) if model.respond_to? :date
 
     str_chunks = new_str.split(/(:notes[~\w]*:)/).map do |note|
       notes_tag = note.scan(/~(\w+)/).flatten

--- a/test/lib/event_generators/fix_events_test.rb
+++ b/test/lib/event_generators/fix_events_test.rb
@@ -10,10 +10,11 @@ class FixEventsTest < ActiveSupport::TestCase
 
   test 'fix events created for all vulns' do
     p = projects(:one)
+    expected_desc = "Here was the commit message.\n<blockquote>\nStrip CRs from *.in files to allow building from webkit.org R=darin\n\nReview URL: http://codereview.chromium.org/39004\n\ngit-svn-id: svn://svn.chromium.org/chrome/trunk/src@11244 0039d316-1c4b-4281-b951-d872f2087c98 \n</blockquote>\n\n[Learn more about this commit](/commits/f3e8965444b0b615ed8aabfcacc5840f6684c0c5)"
     FixEvents.new(p, @silent_logger).generate
-    actual = Event.where(title: "Fix for CVE-2011-3092: Strip CRs from *.in files to allow building from webkit.org").
-                   count
-    assert_equal 1, actual
+    actual = Event.where(title: "Fix for CVE-2011-3092: Strip CRs from *.in files to allow building from webkit.org")
+    assert_equal 1, actual.count 
+    assert_match /.*#{Regexp.escape(expected_desc.strip)}/, actual.first.description.strip
   end
 
 end


### PR DESCRIPTION
Git blame tells me that the in place modification was changed due to ruby 3.0 freezing string literals by default, that's not the case from what I can tell. 