### PR TITLE
Updating dockerfile/compose to match ruby version from the gemfile version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 # uses the specified ruby version - i'm just going from the version in the germfile, so if that changes, this should change
-FROM ruby:2.6.6-alpine
+FROM ruby:3.0-alpine
 
 ENV APP_PATH /var/app
-ENV BUNDLER_VERSION 2.2.6
+ENV BUNDLER_VERSION 2.2.17
 ENV BUNDLE_PATH /usr/local/bundle/gems
 ENV TEMP_PATH /tmp/
 ENV RAILS_LOG_TO_STDOUT true
 ENV RAILS_PORT 3000
+ENV RAILS_DB host.docker.internal
 
 COPY ./entrypoints/dev-docker-entrypoint.sh /usr/local/bin/dev-entrypoint.sh
 COPY ./entrypoints/test-docker-entrypoint.sh /usr/local/bin/test-entrypoint.sh
@@ -30,7 +31,7 @@ RUN apk -U add --no-cache \
     && rm -rf /var/cache/apk* \
     && mkdir -p $APP_PATH
 
-RUN gem install bundler --version 2.2.6 \
+RUN gem install bundler --version 2.2.17 \
 && rm -rf $GEM_HOME/cache/*
 
 WORKDIR $APP_PATH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ services:
     networks:
       - development
       - test
-    # ports:
-    #   - 5432:5432
+    ports:
+      - 5432:5432
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
The Gemfile was updated to ruby 3 in this commit https://github.com/VulnerabilityHistoryProject/vulnerability-history/commit/d28629ebd7cdbeb7f5a82fcd5ce6cf77a2326279, but the dockerfile wasn't. Docker wasn't working for me at 2.6.6 with the current Gemfile, so I updated the ruby version, bundler version, and the db location and now it works (tested on a mac if that matters to anyone)