### PR TITLE
Modified linkifyCVE to allow more than 4 digits for ID

### DIFF
--- a/app/frontend/global/vhpMarkdown.js
+++ b/app/frontend/global/vhpMarkdown.js
@@ -29,7 +29,7 @@ export function vhpMarkdown(str) {
 // The rightmost number can be 4+ digits long according to
 // https://cve.mitre.org/about/faqs.html#cve_id_syntax_change
 function linkifyCVE(str) {
-  const regexp = /(CVE-\d{4}-\d{4,}?)/ig
+  const regexp = /(CVE-\d{4}-\d+)/ig
   const linkText = "[:vulnerability:$1](/cves/$1)"
   return str.replace(regexp, linkText)
 }


### PR DESCRIPTION
#918 using what was recommended in the comments
<img width="537" alt="Screen Shot 2022-01-27 at 8 52 43 PM" src="https://user-images.githubusercontent.com/60411480/151473327-0e96518e-bf3e-450a-b2af-66a823b6e2fc.png">

