### PR TITLE
Issue 916 util tagger

### DIFF
--- a/app/frontend/global/icons.scss
+++ b/app/frontend/global/icons.scss
@@ -109,6 +109,7 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 .vhp-icon-tags          { @extend .fas; @extend .fa-tags; }
 .vhp-icon-timeline      { @extend .fas; @extend .fa-chart-bar; }
 .vhp-icon-upvote        { @extend .fas; @extend .fa-thumbs-up; }
+.vhp-icon-util          { @extend .fas; @extend .fa-toolbox; }
 .vhp-icon-vcc           { @extend .fas; @extend .fa-skull; }
 .vhp-icon-vouch         { @extend .fas; @extend .fa-comments; }
 .vhp-icon-vulnerability { @include vhp-material-icon('bug_report') }

--- a/lib/data_builder.rb
+++ b/lib/data_builder.rb
@@ -111,7 +111,8 @@ class DataBuilder
       SandBoxTagger,
       SpecificationTagger,
       AutoDiscoverableTagger,
-      I18nTagger
+      I18nTagger,
+      UtilTagger
     ].each do |tagger|
       @logger.info "Tagging with #{tagger}"
       t = tagger.new(project)

--- a/lib/taggers/util_tagger.rb
+++ b/lib/taggers/util_tagger.rb
@@ -17,8 +17,9 @@ class UtilTagger
   end
 
   def apply_tags
-    Vulnerability.where(project: @project).each do |v|
-      if is_util_file?(v)  # vcc present
+    Vulnerability.joins(fixes: {commit: :filepaths}).where("filepath LIKE '%util%'").uniq.each do |v|
+      # without this query there were duplicate tags being applied
+      unless VulnerabilityTag.exists?(vulnerability_id: v.id, tag_id: @util_tag.id)
         VulnerabilityTag.create!(
           vulnerability: v,
           tag: @util_tag,
@@ -28,7 +29,5 @@ class UtilTagger
     end
   end
 
-  def is_util_file?(v)
 
-  end
 end

--- a/lib/taggers/util_tagger.rb
+++ b/lib/taggers/util_tagger.rb
@@ -1,0 +1,34 @@
+require_relative '../writing'
+
+class UtilTagger
+
+  def initialize(project)
+    @project = project
+  end
+
+  def create_tags
+    @util_tag = Tag.find_or_create_by!(
+      name: 'Util',
+      shortname: 'util',
+      color: '#FF6700',
+      icon: 'util',
+      description: Writing.tag_article('util')
+    )
+  end
+
+  def apply_tags
+    Vulnerability.where(project: @project).each do |v|
+      if is_util_file?(v)  # vcc present
+        VulnerabilityTag.create!(
+          vulnerability: v,
+          tag: @util_tag,
+          importance: 0.25,
+          )
+      end
+    end
+  end
+
+  def is_util_file?(v)
+
+  end
+end

--- a/test/lib/taggers/util_tag_test.rb
+++ b/test/lib/taggers/util_tag_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+require 'taggers/util_tagger'
+
+class UtilTagTest < ActiveSupport::TestCase
+
+  test 'Util tags created' do
+    t = UtilTagger.new(projects(:one))
+    t.create_tags
+    assert_equal(1, Tag.where(shortname: 'util').size)
+  end
+
+  test 'Util tag not duplicated' do
+    UtilTagger.new(projects(:one))
+    tag_count_before = Tag.all.size
+    if Tag.exists?(shortname: 'util')
+      tag_count_after = Tag.all.size
+      assert_equal(tag_count_before, tag_count_after)
+    end
+  end
+
+  test 'Util tag applied' do
+    t = UtilTagger.new(projects(:one))
+    t.create_tags
+    t.apply_tags
+    tag = Tag.find_by(shortname: 'util')
+    assert(tag)
+  end
+
+end


### PR DESCRIPTION
#916 

Was getting a lot of duplicate tags. Had to apply the following if statement to prevent this from happening
```
unless VulnerabilityTag.exists?(vulnerability_id: v.id, tag_id: @util_tag.id)
```