### PR TITLE
/commits/1 better URLs to fixes and vccs

### DIFF
--- a/app/views/commits/_fix.html.erb
+++ b/app/views/commits/_fix.html.erb
@@ -1,5 +1,7 @@
-<div class="commit-vcc">
-    <i class="vhp-icon-vcc"></i>
-    VCC
-    <a href="/vulnerabilities/<%= @commit.fixes[0].vulnerability.id %>"><%= @commit.fixes[0].vulnerability.cve %></a>
-</div>
+<%= link_to "/#{fix.vulnerability.cve}", class: 'fix link' do %>
+    <i class="vhp-icon-fix"></i>
+    Fix
+    <span class="name">
+        <%= fix.vulnerability.nickname %> <%= fix.vulnerability.cve %>
+    </span>
+<% end %>

--- a/app/views/commits/_vcc.html.erb
+++ b/app/views/commits/_vcc.html.erb
@@ -1,6 +1,7 @@
-<%= link_to vcc.vulnerability, class: 'vcc link' do %>
+<%= link_to "/#{vcc.vulnerability}", class: 'vcc link' do %>
     <i class="vhp-icon-vcc"></i>
     VCC
     <span class="name">
         <%= vcc.vulnerability.nickname %> <%= vcc.vulnerability.cve %>
+    </span>
 <% end %>

--- a/app/views/commits/show.html.erb
+++ b/app/views/commits/show.html.erb
@@ -19,10 +19,7 @@
      by <%=link_to(@commit.developer.nickname, @commit.developer, class: 'nickname') %> <%=@commit.date %>
   </div>
 
-  <div class="cell small-4">
-  </div>
-
-  <div class="cell small-4 sha">
+  <div class="cell small-8 sha">
     commit <%=@commit.commit_hash %> <a href="<%=@commit.github_url %>"> <i class="vhp-icon-github"></i></a>
   </div>
 


### PR DESCRIPTION
### Summary

Turns out we were mixing up VCCs and Fixes anyway, and rendering the URLs inconsistently. So this makes them consistent, and renders to the more permanent link `/CVE-1234-1234` instead of `/vulnerabilities/1`

I also fixed a link break thing on the same page by dividing the page into 2 chunks instead of 3. 

This closes #1007 and is related to #972 

### Have you...

  - [x] Linked this PR to an issue?
  - [ ] Written any automated tests?
  - [x] Removed all debug statements?  
  - [x] Refactored your code to be maintainable?
  - [x] Checked that `Gemfile.lock` and `yarn.lock` are't getting modified unintentionally?
  - [x] Marked as Draft if it's unfinished?

The above things are not required, but appreciated.