### PR TITLE
Fix offenders vulnerabilities query

### DIFF
--- a/app/models/filepath.rb
+++ b/app/models/filepath.rb
@@ -58,33 +58,15 @@ class Filepath < ApplicationRecord
       select("JSON_OBJECT_AGG(vulnerabilities.cve , JSON_BUILD_OBJECT(
           'nickname', vulnerabilities.nickname,
           'upvotes', vulnerabilities.upvotes )) AS cves").
-      where('is_code = TRUE') 
+      where('is_code = TRUE')
   end
 
   def vulnerabilities(short_descriptions)
-    @fp = Vulnerability.
-        joins([:project, fixes: {commit: :filepaths}]).
-        left_outer_joins(:vulnerability_tags).
-        where('filepaths.id' => id).
-        select("vulnerabilities.id as id").
-        select("vulnerabilities.cve as cve").
-        select("vulnerabilities.announced").
-        select("vulnerabilities.upvotes").
-        select("vulnerabilities.nickname").
-        select("max(projects.name) AS project_name").
-        select("max(projects.subdomain) AS subdomain").
-        select("JSON_AGG(JSON_BUILD_OBJECT(
-                'id', vulnerability_tags.tag_id,
-                'importance', vulnerability_tags.importance
-                ) ORDER BY importance DESC) AS tag_json").
-        group('vulnerabilities.id').
-        order('vulnerabilities.upvotes desc')
-
-    if short_descriptions
-      @fp.select('vulnerabilities.short_desc as short_desc')
-    else
-      @fp.select('vulnerabilities.description as description')
-    end
+    vuln_subquery = Vulnerability.
+      joins([fixes: {commit: :filepaths}]).
+      where('filepaths.id' => id).
+      select(:id)
+    Vulnerability.list_all(short_descriptions).where(id: vuln_subquery)
   end
 
   def contributors


### PR DESCRIPTION
For example, the page: https://vulnerabilityhistory.org/filepaths/django-django-utils-http-py#vulnerabilities was showing tons of repeated tags.

Turns out we had a bad query that was copy-pasted. Instead, I made it a subquery (gasp) and reused the original code

